### PR TITLE
Bump Redis image from 7-alpine to 8-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     container_name: yaptide_redis
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
This pull request updates the Redis service in the `docker-compose.yml` file to use a newer version of the Redis image.

Version update:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L5-R5): Updated the Redis image from `redis:7-alpine` to `redis:8-alpine` to ensure compatibility with the latest features and security updates.