### PR TITLE
Allow for filtering jobs by job_state

### DIFF
--- a/yaptide/routes/user_routes.py
+++ b/yaptide/routes/user_routes.py
@@ -1,7 +1,8 @@
 import logging
 from enum import Enum
+from typing import List
 
-from flask import request, current_app as app
+from flask import request
 from flask_restful import Resource
 from marshmallow import Schema, fields, ValidationError
 from sqlalchemy import asc, desc
@@ -30,7 +31,7 @@ class OrderBy(Enum):
     END_TIME = "end_time"
 
 
-def validate_job_state(states: [str]):
+def validate_job_state(states: List[str]):
     """check if all states are correct values of EntityState enum"""
     if not set(states).issubset({es.value for es in EntityState}):
         raise ValidationError('Invalid job state')
@@ -42,7 +43,7 @@ class JobStateField(fields.Field):
     @staticmethod
     def _deserialize(value, attr, data, **kwargs):
         """deserializes job_state, which is expected to come as comma-separated list of states"""
-        return value.split(',')
+        return value.split(',') if isinstance(value, str) else []
 
 
 class UserSimulations(Resource):

--- a/yaptide/routes/user_routes.py
+++ b/yaptide/routes/user_routes.py
@@ -31,7 +31,7 @@ class OrderBy(Enum):
 
 
 def validate_job_state(states):
-    """ check whether the list of job states in query contains actual enum values """
+    """check whether the list of job states in query contains actual enum values"""
     app.logger.error(f'states {states}')
     valid_states = [es.value for es in EntityState]
     for state in states:
@@ -40,9 +40,11 @@ def validate_job_state(states):
 
 
 class JobStateField(fields.Field):
+    """custom deserializer for job_state field"""
+
     @staticmethod
     def _deserialize(value, attr, data, **kwargs):
-        """ deserializes job_state, which is expected to come as comma-separated list of states """
+        """deserializes job_state, which is expected to come as comma-separated list of states"""
         return value.split(',')
 
 

--- a/yaptide/routes/user_routes.py
+++ b/yaptide/routes/user_routes.py
@@ -39,7 +39,7 @@ def validate_job_state(states):
             raise ValidationError('Invalid job state')
 
 
-class JobStateField(fields.Field[list[str]]):
+class JobStateField(fields.Field):
     @staticmethod
     def _deserialize(value, attr, data, **kwargs):
         """ deserializes job_state, which is expected to come as comma-separated list of states """

--- a/yaptide/routes/user_routes.py
+++ b/yaptide/routes/user_routes.py
@@ -30,13 +30,10 @@ class OrderBy(Enum):
     END_TIME = "end_time"
 
 
-def validate_job_state(states):
-    """check whether the list of job states in query contains actual enum values"""
-    app.logger.error(f'states {states}')
-    valid_states = [es.value for es in EntityState]
-    for state in states:
-        if state not in valid_states:
-            raise ValidationError('Invalid job state')
+def validate_job_state(states: [str]):
+    """check if all states are correct values of EntityState enum"""
+    if not set(states).issubset({es.value for es in EntityState}):
+        raise ValidationError('Invalid job state')
 
 
 class JobStateField(fields.Field):

--- a/yaptide/routes/user_routes.py
+++ b/yaptide/routes/user_routes.py
@@ -1,5 +1,4 @@
 import logging
-import typing
 from enum import Enum
 
 from flask import request, current_app as app
@@ -32,15 +31,20 @@ class OrderBy(Enum):
 
 
 def validate_job_state(states):
+    """ check whether the list of job states in query contains actual enum values """
     app.logger.error(f'states {states}')
     valid_states = [es.value for es in EntityState]
     for state in states:
         if state not in valid_states:
             raise ValidationError('Invalid job state')
 
+
 class JobStateField(fields.Field[list[str]]):
-    def _deserialize(self, value, attr, data, **kwargs):
+    @staticmethod
+    def _deserialize(value, attr, data, **kwargs):
+        """ deserializes job_state, which is expected to come as comma-separated list of states """
         return value.split(',')
+
 
 class UserSimulations(Resource):
     """Class responsible for returning user's simulations' basic infos"""


### PR DESCRIPTION
This PR adds `job_state` query param with validation for fetching simulations which allows to select simulations with subset of states. This is required 1) to filter out UNKNOWN simulations which front end is not able to display 2) add "Last 5 simulations" section with only PENDING, RUNNING, MERGING, COMPLETED states