### PR TITLE
fix: update default value for encryption salt in encryption_options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,4 +293,4 @@ yaptide_tester/output/
 # deploy keys
 server.crt
 server.key
-docs/openapi.yaml
+download/

--- a/yaptide/admin/simulators.py
+++ b/yaptide/admin/simulators.py
@@ -85,7 +85,7 @@ def encryption_options(required: bool = False):
         @click.option('--salt',
                       type=click.STRING,
                       envvar='S3_ENCRYPTION_SALT',
-                      default=password,
+                      default=salt,
                       required=required,
                       help='encryption salt')
         @wraps(func)


### PR DESCRIPTION
This pull request introduces improvements to S3 file upload handling and error reporting, as well as a minor fix in the CLI options for simulators. The most significant changes involve configuring the S3 client to avoid checksum errors with certain endpoints and enhancing error messages for failed uploads.

**S3 Client Configuration and Error Handling:**

* Added the import of `Config` from `botocore` to support new S3 client configuration.
* Updated the S3 client initialization in `upload_file_to_s3` to disable flexible checksums, which helps prevent `XAmzContentSHA256Mismatch` errors with S3-compatible endpoints that do not support aws-chunked encoding.
* Improved error handling in `upload_file_to_s3` by extracting the error message more robustly and displaying it in a clearer format if the upload fails.

**CLI Option Fix:**

* Fixed the default value for the `--salt` CLI option in the simulator decorator to use the correct variable (`salt` instead of `password`).