### PR TITLE
Remove sleep delays and standarize time-related variables

### DIFF
--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -19,11 +19,10 @@ REQUESTED_MATCH = r"\bRequested number of primaries NSTAT"
 TIMEOUT_MATCH = r"\bTimeout occured"
 
 
-def log_generator(
-        thefile: TextIOWrapper, 
-        event: threading.Event = None, 
-        max_idle_seconds: float = 3600, 
-        polling_interval_seconds: float = 1) -> Iterator[str]:
+def log_generator(thefile: TextIOWrapper,
+                  event: threading.Event = None,
+                  max_idle_seconds: float = 3600,
+                  polling_interval_seconds: float = 1) -> Iterator[str]:
     """
     Generator equivalent to `tail -f` Linux command.
     Yields new lines appended to the end of the file.
@@ -81,25 +80,24 @@ def send_task_update(sim_id: int, task_id: str, update_key: str, update_dict: di
     return True
 
 
-def read_shieldhit_file(
-        filepath: Path, 
-        sim_id: int, 
-        task_id: int, 
-        update_key: str, 
-        backend_url: str,
-        max_wait_for_file_seconds: float = 30,
-        max_idle_seconds: float = 3600,
-        update_interval_seconds: float = 2,
-        polling_interval_seconds: float = 1):  # skipcq: PYL-W0613
+def read_shieldhit_file(filepath: Path,
+                        sim_id: int,
+                        task_id: int,
+                        update_key: str,
+                        backend_url: str,
+                        max_wait_for_file_seconds: float = 30,
+                        max_idle_seconds: float = 3600,
+                        update_interval_seconds: float = 2,
+                        polling_interval_seconds: float = 1):  # skipcq: PYL-W0613
     """
     Monitors log file of a shieldhit task and sends updates to the backend.
-    
+
     Args:
-        max_wait_for_file_seconds: Maximum time to wait for the log file to be created 
+        max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
         update_interval_seconds: Minimum interval between successive updates to the backend.
-        polling_interval_seconds: Interval between successive file polls while no new 
+        polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
     """
     logging.debug("Started monitoring, simulation id: %d, task id: %s", sim_id, task_id)
@@ -128,11 +126,10 @@ def read_shieldhit_file(
         logging.debug("Update for task: %d - FAILED", task_id)
         return
 
-    loglines = log_generator(
-        logfile, 
-        threading.Event(), 
-        max_idle_seconds=max_idle_seconds, 
-        polling_interval_seconds=polling_interval_seconds)
+    loglines = log_generator(logfile,
+                             threading.Event(),
+                             max_idle_seconds=max_idle_seconds,
+                             polling_interval_seconds=polling_interval_seconds)
     for line in loglines:
         utc_now = datetime.utcnow()
         if re.search(RUN_MATCH, line):
@@ -225,7 +222,7 @@ if __name__ == "__main__":
     logging.info("update_key %s", args.update_key)
     logging.info("backend_url %s", args.backend_url)
     read_shieldhit_file(filepath=Path(args.filepath),
-              sim_id=args.sim_id,
-              task_id=args.task_id,
-              update_key=args.update_key,
-              backend_url=args.backend_url)
+                        sim_id=args.sim_id,
+                        task_id=args.task_id,
+                        update_key=args.update_key,
+                        backend_url=args.backend_url)

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -16,7 +16,6 @@ import math
 RUN_MATCH = r"\bPrimary particle no.\s*\d*\s*ETR:\s*\d*\s*hour.*\d*\s*minute.*\d*\s*second.*\b"
 COMPLETE_MATCH = r"\bRun time:\s*\d*\s*hour.*\d*\s*minute.*\d*\s*second.*\b"
 REQUESTED_MATCH = r"\bRequested number of primaries NSTAT"
-TIMEOUT_MATCH = r"\bTimeout occured"
 
 
 def log_generator(thefile: TextIOWrapper,
@@ -31,15 +30,15 @@ def log_generator(thefile: TextIOWrapper,
     Args:
         thefile: File object to read from.
         event: Threading event to signal when to stop the generator.
-        max_idle_seconds: Maximum time to wait for new data before stopping the generator.
+        max_idle_seconds: Maximum time to wait for new data before stopping the generator. If it gets exceeded, TimeoutError is raised.
         polling_interval_seconds: Interval between successive file polls while no new data is available.
     """
+    if thefile is None:
+        raise ValueError("File object cannot be None.")
     idle_seconds = 0
     while True:
         if event and event.is_set():
             break
-        if thefile is None:
-            return "File not found"
         line = thefile.readline()
         if not line:
             if event:
@@ -49,7 +48,7 @@ def log_generator(thefile: TextIOWrapper,
                 time.sleep(polling_interval_seconds)
             idle_seconds += polling_interval_seconds
             if idle_seconds >= max_idle_seconds:
-                return "Timeout occured"
+                raise TimeoutError("No new log data received before timeout.")
             continue
         idle_seconds = 0
         yield line
@@ -139,71 +138,72 @@ def read_shieldhit_file(filepath: Path,
                              threading.Event(),
                              max_idle_seconds=max_idle_seconds,
                              polling_interval_seconds=polling_interval_seconds)
-    for line in loglines:
-        utc_now = datetime.utcnow()
-        if re.search(RUN_MATCH, line):
-            logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
-            if utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds:
-                logging.debug("Skipping update, too often")
-                continue
-            last_update_timestamp_seconds = utc_now.timestamp()
-            splitted = line.split()
-            up_dict = {  # skipcq: PYL-W0612
-                "simulated_primaries": int(splitted[3]),
-                "estimated_time": int(splitted[9]) + int(splitted[7]) * 60 + int(splitted[5]) * 3600
-            }
-            send_task_update(sim_id=sim_id,
-                             task_id=task_id,
-                             update_key=update_key,
-                             update_dict=up_dict,
-                             backend_url=backend_url)
-            logging.debug("Update for task: %d - simulated primaries: %s", task_id, splitted[3])
+    try:
+        for line in loglines:
+            utc_now = datetime.utcnow()
+            if re.search(RUN_MATCH, line):
+                logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
+                if utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds:
+                    logging.debug("Skipping update, too often")
+                    continue
+                last_update_timestamp_seconds = utc_now.timestamp()
+                splitted = line.split()
+                up_dict = {  # skipcq: PYL-W0612
+                    "simulated_primaries": int(splitted[3]),
+                    "estimated_time": int(splitted[9]) + int(splitted[7]) * 60 + int(splitted[5]) * 3600
+                }
+                send_task_update(sim_id=sim_id,
+                                 task_id=task_id,
+                                 update_key=update_key,
+                                 update_dict=up_dict,
+                                 backend_url=backend_url)
+                logging.debug("Update for task: %d - simulated primaries: %s", task_id, splitted[3])
 
-        elif re.search(REQUESTED_MATCH, line):
-            logging.debug("Found REQUESTED_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
-            splitted = line.split(": ")
-            up_dict = {  # skipcq: PYL-W0612
-                "simulated_primaries": 0,
-                "requested_primaries": int(splitted[1]),
-                "start_time": utc_now.isoformat(sep=" "),
-                "task_state": "RUNNING"
-            }
-            send_task_update(sim_id=sim_id,
-                             task_id=task_id,
-                             update_key=update_key,
-                             update_dict=up_dict,
-                             backend_url=backend_url)
-            logging.debug("Update for task: %d - RUNNING", task_id)
+            elif re.search(REQUESTED_MATCH, line):
+                logging.debug("Found REQUESTED_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
+                splitted = line.split(": ")
+                up_dict = {  # skipcq: PYL-W0612
+                    "simulated_primaries": 0,
+                    "requested_primaries": int(splitted[1]),
+                    "start_time": utc_now.isoformat(sep=" "),
+                    "task_state": "RUNNING"
+                }
+                send_task_update(sim_id=sim_id,
+                                 task_id=task_id,
+                                 update_key=update_key,
+                                 update_dict=up_dict,
+                                 backend_url=backend_url)
+                logging.debug("Update for task: %d - RUNNING", task_id)
 
-        elif re.search(COMPLETE_MATCH, line):
-            logging.debug("Found COMPLETE_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
-            up_dict = {  # skipcq: PYL-W0612
-                "end_time": utc_now.isoformat(sep=" "),
-                "task_state": "COMPLETED"
-            }
-            send_task_update(sim_id=sim_id,
-                             task_id=task_id,
-                             update_key=update_key,
-                             update_dict=up_dict,
-                             backend_url=backend_url)
-            logging.debug("Update for task: %d - COMPLETED", task_id)
-            return
-
-        elif re.search(TIMEOUT_MATCH, line):
-            logging.debug("Found TIMEOUT_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
-            up_dict = {  # skipcq: PYL-W0612
-                "task_state": "FAILED",
-                "end_time": datetime.utcnow().isoformat(sep=" ")
-            }
-            send_task_update(sim_id=sim_id,
-                             task_id=task_id,
-                             update_key=update_key,
-                             update_dict=up_dict,
-                             backend_url=backend_url)
-            print("Update for task: %d - TIMEOUT", task_id)
-            return
-        else:
-            logging.debug("No match found in line: %s for file: %s and task: %s ", line, filepath, task_id)
+            elif re.search(COMPLETE_MATCH, line):
+                logging.debug("Found COMPLETE_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
+                up_dict = {  # skipcq: PYL-W0612
+                    "end_time": utc_now.isoformat(sep=" "),
+                    "task_state": "COMPLETED"
+                }
+                send_task_update(sim_id=sim_id,
+                                 task_id=task_id,
+                                 update_key=update_key,
+                                 update_dict=up_dict,
+                                 backend_url=backend_url)
+                logging.debug("Update for task: %d - COMPLETED", task_id)
+                return
+            else:
+                logging.debug("No match found in line: %s for file: %s and task: %s ", line, filepath, task_id)
+    except TimeoutError as err:
+        logging.warning("Log monitoring timed out for file %s and task %s: %s", filepath, task_id, err)
+        up_dict = {  # skipcq: PYL-W0612
+            "task_state": "FAILED",
+            "end_time": datetime.utcnow().isoformat(sep=" ")
+        }
+        send_task_update(sim_id=sim_id,
+                         task_id=task_id,
+                         update_key=update_key,
+                         update_dict=up_dict,
+                         backend_url=backend_url)
+        logging.debug("Update for task: %d - TIMEOUT", task_id)
+    
+    raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen.")
 
 
 if __name__ == "__main__":

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -7,7 +7,7 @@ import signal
 import ssl
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import datetime
 from io import TextIOWrapper
 from pathlib import Path
 from urllib import request

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -126,7 +126,7 @@ def read_shieldhit_file(filepath: Path,
             logging.debug("Log file for task %s not found", task_id)
             up_dict = {  # skipcq: PYL-W0612
                 "task_state": "FAILED",
-                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+                "end_time": datetime.utcnow().isoformat(sep=" ")
             }
             send_task_update(sim_id=sim_id,
                              task_id=task_id,
@@ -142,7 +142,7 @@ def read_shieldhit_file(filepath: Path,
                                  polling_interval_seconds=polling_interval_seconds)
 
         for line in loglines:
-            utc_now = datetime.now(timezone.utc)
+            utc_now = datetime.utcnow()
             if re.search(RUN_MATCH, line):
                 logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
                 if utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds:
@@ -199,7 +199,7 @@ def read_shieldhit_file(filepath: Path,
         logging.warning("Log monitoring timed out for file %s and task %s: %s", filepath, task_id, err)
         up_dict = {  # skipcq: PYL-W0612
             "task_state": "FAILED",
-            "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+            "end_time": datetime.utcnow().isoformat(sep=" ")
         }
         send_task_update(sim_id=sim_id,
                          task_id=task_id,
@@ -211,7 +211,7 @@ def read_shieldhit_file(filepath: Path,
         logging.error("Error while monitoring log file %s for task %s: %s", filepath, task_id, err)
         up_dict = {  # skipcq: PYL-W0612
             "task_state": "FAILED",
-            "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+            "end_time": datetime.utcnow().isoformat(sep=" ")
         }
         send_task_update(sim_id=sim_id,
                          task_id=task_id,

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -30,7 +30,7 @@ def log_generator(thefile: TextIOWrapper,
     Args:
         thefile: File object to read from.
         event: Threading event to signal when to stop the generator.
-        max_idle_seconds: Maximum time to wait for new data before stopping the generator. If it gets exceeded, TimeoutError is raised.
+        max_idle_seconds: Maximum time to wait for new data before raising TimeoutError.
         polling_interval_seconds: Interval between successive file polls while no new data is available.
     """
     if thefile is None:
@@ -204,7 +204,8 @@ def read_shieldhit_file(filepath: Path,
         logging.debug("Update for task: %d - TIMEOUT", task_id)
 
     raise RuntimeError(
-        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen."
+        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
+        f"This should never happen."
     )
 
 

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -219,6 +219,9 @@ def read_shieldhit_file(filepath: Path,
                          update_dict=up_dict,
                          backend_url=backend_url)
         logging.debug("Update for task: %d - ERROR", task_id)
+    finally:
+        if logfile is not None:
+            logfile.close()
 
 
 if __name__ == "__main__":

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -29,6 +29,8 @@ def log_generator(thefile: TextIOWrapper,
     Main purpose is monitoring of the log files.
 
     Args:
+        thefile: File object to read from.
+        event: Threading event to signal when to stop the generator.
         max_idle_seconds: Maximum time to wait for new data before stopping the generator.
         polling_interval_seconds: Interval between successive file polls while no new data is available.
     """
@@ -95,6 +97,11 @@ def read_shieldhit_file(filepath: Path,
     (like simulation failed or completed).
 
     Args:
+        filepath: Path to the log file to monitor.
+        sim_id: Simulation ID.
+        task_id: Task ID.
+        update_key: Simulation auth token for backend updates.
+        backend_url: URL of the backend server to send updates to.
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -54,7 +54,7 @@ def log_generator(thefile: TextIOWrapper,
         yield line
 
 
-def send_task_update(sim_id: int, task_id: str, update_key: str, update_dict: dict, backend_url: str) -> bool:
+def send_task_update(sim_id: int, task_id: int, update_key: str, update_dict: dict, backend_url: str) -> bool:
     """Sends task update to flask to update database"""
     if not backend_url:
         logging.error("Backend url not specified")

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -90,7 +90,9 @@ def read_shieldhit_file(filepath: Path,
                         update_interval_seconds: float = 2,
                         polling_interval_seconds: float = 1):  # skipcq: PYL-W0613
     """
-    Monitors log file of a shieldhit task and sends updates to the backend.
+    Monitors log file of a shieldhit task and sends updates to the backend. 
+    The purpose of the updates is the progress bar update and state updates 
+    (like simulation failed or completed).
 
     Args:
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -202,8 +202,10 @@ def read_shieldhit_file(filepath: Path,
                          update_dict=up_dict,
                          backend_url=backend_url)
         logging.debug("Update for task: %d - TIMEOUT", task_id)
-    
-    raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen.")
+
+    raise RuntimeError(
+        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen."
+    )
 
 
 if __name__ == "__main__":

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -7,7 +7,7 @@ import signal
 import ssl
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from io import TextIOWrapper
 from pathlib import Path
 from urllib import request
@@ -93,7 +93,8 @@ def read_shieldhit_file(filepath: Path,
     """
     Monitors log file of a shieldhit task and sends updates to the backend.
     The purpose of the updates is the progress bar update and state updates
-    (like simulation failed or completed).
+    (like simulation failed or completed). All possible exceptions are caught and logged,
+    and in case of any exception the task is marked as FAILED.
 
     Args:
         filepath: Path to the log file to monitor.
@@ -108,39 +109,40 @@ def read_shieldhit_file(filepath: Path,
         polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
     """
-    logging.debug("Started monitoring, simulation id: %d, task id: %s", sim_id, task_id)
-    logfile = None
-    last_update_timestamp_seconds = 0
-
-    open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
-    for _ in range(open_file_attempts):
-        try:
-            logfile = open(filepath)  # skipcq: PTC-W6004
-            break
-        except FileNotFoundError:
-            time.sleep(polling_interval_seconds)
-
-    if logfile is None:
-        logging.debug("Log file for task %s not found", task_id)
-        up_dict = {  # skipcq: PYL-W0612
-            "task_state": "FAILED",
-            "end_time": datetime.utcnow().isoformat(sep=" ")
-        }
-        send_task_update(sim_id=sim_id,
-                         task_id=task_id,
-                         update_key=update_key,
-                         update_dict=up_dict,
-                         backend_url=backend_url)
-        logging.debug("Update for task: %d - FAILED", task_id)
-        return
-
-    loglines = log_generator(logfile,
-                             threading.Event(),
-                             max_idle_seconds=max_idle_seconds,
-                             polling_interval_seconds=polling_interval_seconds)
     try:
+        logging.debug("Started monitoring, simulation id: %d, task id: %s", sim_id, task_id)
+        logfile = None
+        last_update_timestamp_seconds = 0
+
+        open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
+        for _ in range(open_file_attempts):
+            try:
+                logfile = open(filepath)  # skipcq: PTC-W6004
+                break
+            except FileNotFoundError:
+                time.sleep(polling_interval_seconds)
+
+        if logfile is None:
+            logging.debug("Log file for task %s not found", task_id)
+            up_dict = {  # skipcq: PYL-W0612
+                "task_state": "FAILED",
+                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+            }
+            send_task_update(sim_id=sim_id,
+                             task_id=task_id,
+                             update_key=update_key,
+                             update_dict=up_dict,
+                             backend_url=backend_url)
+            logging.debug("Update for task: %d - FAILED", task_id)
+            return
+
+        loglines = log_generator(logfile,
+                                 threading.Event(),
+                                 max_idle_seconds=max_idle_seconds,
+                                 polling_interval_seconds=polling_interval_seconds)
+
         for line in loglines:
-            utc_now = datetime.utcnow()
+            utc_now = datetime.now(timezone.utc)
             if re.search(RUN_MATCH, line):
                 logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %s ", line, filepath, task_id)
                 if utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds:
@@ -190,11 +192,14 @@ def read_shieldhit_file(filepath: Path,
                 return
             else:
                 logging.debug("No match found in line: %s for file: %s and task: %s ", line, filepath, task_id)
+
+        raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
+                           f"This should never happen.")
     except TimeoutError as err:
         logging.warning("Log monitoring timed out for file %s and task %s: %s", filepath, task_id, err)
         up_dict = {  # skipcq: PYL-W0612
             "task_state": "FAILED",
-            "end_time": datetime.utcnow().isoformat(sep=" ")
+            "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
         }
         send_task_update(sim_id=sim_id,
                          task_id=task_id,
@@ -202,11 +207,18 @@ def read_shieldhit_file(filepath: Path,
                          update_dict=up_dict,
                          backend_url=backend_url)
         logging.debug("Update for task: %d - TIMEOUT", task_id)
-
-    raise RuntimeError(
-        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
-        f"This should never happen."
-    )
+    except Exception as err:
+        logging.error("Error while monitoring log file %s for task %s: %s", filepath, task_id, err)
+        up_dict = {  # skipcq: PYL-W0612
+            "task_state": "FAILED",
+            "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+        }
+        send_task_update(sim_id=sim_id,
+                         task_id=task_id,
+                         update_key=update_key,
+                         update_dict=up_dict,
+                         backend_url=backend_url)
+        logging.debug("Update for task: %d - ERROR", task_id)
 
 
 if __name__ == "__main__":

--- a/yaptide/batch/watcher.py
+++ b/yaptide/batch/watcher.py
@@ -92,8 +92,8 @@ def read_shieldhit_file(filepath: Path,
                         update_interval_seconds: float = 2,
                         polling_interval_seconds: float = 1):  # skipcq: PYL-W0613
     """
-    Monitors log file of a shieldhit task and sends updates to the backend. 
-    The purpose of the updates is the progress bar update and state updates 
+    Monitors log file of a shieldhit task and sends updates to the backend.
+    The purpose of the updates is the progress bar update and state updates
     (like simulation failed or completed).
 
     Args:

--- a/yaptide/celery/tasks.py
+++ b/yaptide/celery/tasks.py
@@ -10,7 +10,7 @@ from typing import Optional
 from yaptide.batch.batch_methods import post_update
 from yaptide.celery.utils.pymc import (average_estimators, command_to_run_fluka, command_to_run_shieldhit,
                                        execute_simulation_subprocess, get_fluka_estimators, get_shieldhit_estimators,
-                                       get_tmp_dir, read_file, read_file_offline, read_fluka_file)
+                                       get_tmp_dir, read_shieldhit_file, read_file_offline, read_fluka_file)
 from yaptide.celery.utils.requests import (send_simulation_logfiles, send_simulation_results, send_task_update)
 from yaptide.celery.simulation_worker import celery_app
 from yaptide.utils.enums import EntityState
@@ -296,7 +296,7 @@ def monitor_shieldhit(event: threading.Event, tmp_work_dir: str, task_id: int, u
     path_to_monitor = Path(tmp_work_dir) / f"shieldhit_{task_id:04d}.log"
     if update_key and simulation_id is not None:
         current_logging_level = logging.getLogger().getEffectiveLevel()
-        task = threading.Thread(target=read_file,
+        task = threading.Thread(target=read_shieldhit_file,
                                 kwargs=dict(event=event,
                                             filepath=path_to_monitor,
                                             simulation_id=simulation_id,

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -114,7 +114,7 @@ def read_fluka_out_file(event: threading.Event,
                         verbose: bool = False) -> None:
     """
     Function reading the fluka output file and reporting progress to the backend.
-    
+
     Args:
         update_interval_seconds: Minimum interval between progress updates in seconds.
     """

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -75,8 +75,11 @@ def check_progress(line: str, update_interval_seconds: float, details: TaskDetai
     Function checking if the line contains progress information and sending update if needed.
 
     Args:
+        line: Line to be checked for progress information.
         update_interval_seconds: Minimum interval between progress updates in seconds.
-
+        details: TaskDetails object containing details about the task.
+        progress_details: ProgressDetails object containing details about the progress.
+        
     Returns:
         True if the line contained progress information, False otherwise.
     """
@@ -116,6 +119,9 @@ def read_fluka_out_file(event: threading.Event,
     Function reading the fluka output file and reporting progress to the backend.
 
     Args:
+        event: Threading event to signal when to stop monitoring.
+        line_iterator: Iterator over lines of the log file to be monitored.
+        details: TaskDetails object containing details about the task.
         update_interval_seconds: Minimum interval between progress updates in seconds.
     """
     in_progress = False

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -168,5 +168,6 @@ def read_fluka_out_file(event: threading.Event,
         return
 
     raise RuntimeError(
-        f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. This should never happen."
+        f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. "
+        "This should never happen."
     )

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -122,50 +122,50 @@ def read_fluka_out_file(event: threading.Event,
         event: Threading event to signal when to stop monitoring.
         line_iterator: Iterator over lines of the log file to be monitored.
         details: TaskDetails object containing details about the task.
-        update_interval_seconds: Minimum interval between progress updates in seconds.
     """
     in_progress = False
     progress_details = ProgressDetails(utc_now=time_now_utc())
-    for line in line_iterator:
-        if event.is_set():
-            return
-        progress_details.utc_now = time_now_utc()
-        if in_progress:
-            if check_progress(line=line,
-                              update_interval_seconds=update_interval_seconds,
-                              details=details,
-                              progress_details=progress_details):
-                continue
-            if line.startswith(S_OK_OUT_COLLECTED):
-                in_progress = False
-                if verbose:
-                    logger.debug("Found end of simulation calculation line")
-                continue
-        else:
-            if line.startswith(S_OK_OUT_IN_PROGRESS):
-                in_progress = True
-                if verbose:
-                    logger.debug("Found progress line")
-                continue
-            if line.startswith(S_OK_OUT_START):
-                logger.debug("Found start of the simulation")
-                continue
-            if S_OK_OUT_FIN_PRE_CHECK in line and re.match(S_OK_OUT_FIN_PATTERN, line):
-                logger.debug("Found end of the simulation")
-                break
-        # handle generator timeout
-        if re.search(TIMEOUT_MATCH, line):
-            logging.error("Simulation watcher %s timed out", details.task_id)
-            up_dict = {"task_state": EntityState.FAILED.value, "end_time": time_now_utc().isoformat(sep=" ")}
-            send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
-            return
+    try:
+        for line in line_iterator:
+            if event.is_set():
+                return
+            progress_details.utc_now = time_now_utc()
+            if in_progress:
+                if check_progress(line=line,
+                                update_interval_seconds=update_interval_seconds,
+                                details=details,
+                                progress_details=progress_details):
+                    continue
+                if line.startswith(S_OK_OUT_COLLECTED):
+                    in_progress = False
+                    if verbose:
+                        logger.debug("Found end of simulation calculation line")
+                    continue
+            else:
+                if line.startswith(S_OK_OUT_IN_PROGRESS):
+                    in_progress = True
+                    if verbose:
+                        logger.debug("Found progress line")
+                    continue
+                if line.startswith(S_OK_OUT_START):
+                    logger.debug("Found start of the simulation")
+                    continue
+                if S_OK_OUT_FIN_PRE_CHECK in line and re.match(S_OK_OUT_FIN_PATTERN, line):
+                    logger.debug("Found end of the simulation")
+                    logger.info("Parsing log file for task %s finished", details.task_id)
+                    up_dict = {
+                        "simulated_primaries": progress_details.requested_primaries,
+                        "end_time": utc_without_offset(progress_details.utc_now),
+                        "task_state": EntityState.COMPLETED.value
+                    }
+                    logger.info("Sending final update for task %d, simulated primaries %d", details.task_id,
+                                progress_details.requested_primaries)
+                    send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
+                    return 
+    except TimeoutError as err:
+        logger.error("Simulation watcher %s timed out: %s", details.task_id, err)
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": time_now_utc().isoformat(sep=" ")}
+        send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
+        return
 
-    logging.info("Parsing log file for task %s finished", details.task_id)
-    up_dict = {
-        "simulated_primaries": progress_details.requested_primaries,
-        "end_time": utc_without_offset(progress_details.utc_now),
-        "task_state": EntityState.COMPLETED.value
-    }
-    logging.info("Sending final update for task %d, simulated primaries %d", details.task_id,
-                 progress_details.requested_primaries)
-    send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
+    raise RuntimeError(f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. This should never happen.")

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -3,8 +3,7 @@ from datetime import datetime, timezone
 import logging
 import re
 import threading
-from typing import Iterator, Optional, Tuple
-from yaptide.batch.watcher import TIMEOUT_MATCH
+from typing import Iterator, Optional
 
 from yaptide.celery.utils.requests import send_task_update
 from yaptide.utils.enums import EntityState
@@ -45,7 +44,7 @@ class TaskDetails:
     """Class holding details about the task."""
 
     simulation_id: int
-    task_id: str
+    task_id: int
     update_key: str
 
 

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -131,9 +131,9 @@ def read_fluka_out_file(event: threading.Event,
             progress_details.utc_now = time_now_utc()
             if in_progress:
                 if check_progress(line=line,
-                                update_interval_seconds=update_interval_seconds,
-                                details=details,
-                                progress_details=progress_details):
+                                  update_interval_seconds=update_interval_seconds,
+                                  details=details,
+                                  progress_details=progress_details):
                     continue
                 if line.startswith(S_OK_OUT_COLLECTED):
                     in_progress = False
@@ -160,11 +160,13 @@ def read_fluka_out_file(event: threading.Event,
                     logger.info("Sending final update for task %d, simulated primaries %d", details.task_id,
                                 progress_details.requested_primaries)
                     send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
-                    return 
+                    return
     except TimeoutError as err:
         logger.error("Simulation watcher %s timed out: %s", details.task_id, err)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": time_now_utc().isoformat(sep=" ")}
         send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
         return
 
-    raise RuntimeError(f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. This should never happen.")
+    raise RuntimeError(
+        f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. This should never happen."
+    )

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -162,6 +162,7 @@ def read_fluka_out_file(event: threading.Event,
                             progress_details.requested_primaries)
                 send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
                 return
-
-    raise RuntimeError(f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. "
-                       "This should never happen.")
+    if not event.is_set():
+        raise RuntimeError(
+            f"Log stream ended without completion markers in SHIELDHIT monitor for task {details.task_id}. "
+            f"This should never happen.")

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -79,7 +79,7 @@ def check_progress(line: str, update_interval_seconds: float, details: TaskDetai
         update_interval_seconds: Minimum interval between progress updates in seconds.
         details: TaskDetails object containing details about the task.
         progress_details: ProgressDetails object containing details about the progress.
-        
+
     Returns:
         True if the line contained progress information, False otherwise.
     """

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -164,5 +164,5 @@ def read_fluka_out_file(event: threading.Event,
                 return
     if not event.is_set():
         raise RuntimeError(
-            f"Log stream ended without completion markers in SHIELDHIT monitor for task {details.task_id}. "
+            f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. "
             f"This should never happen.")

--- a/yaptide/celery/utils/progress/fluka_monitor.py
+++ b/yaptide/celery/utils/progress/fluka_monitor.py
@@ -120,54 +120,48 @@ def read_fluka_out_file(event: threading.Event,
     Args:
         event: Threading event to signal when to stop monitoring.
         line_iterator: Iterator over lines of the log file to be monitored.
+        update_interval_seconds: Minimum interval between successive updates to the backend.
         details: TaskDetails object containing details about the task.
+        verbose: If True, debug logs will be printed. Default is False.
     """
     in_progress = False
     progress_details = ProgressDetails(utc_now=time_now_utc())
-    try:
-        for line in line_iterator:
-            if event.is_set():
+    for line in line_iterator:
+        if event.is_set():
+            return
+        progress_details.utc_now = time_now_utc()
+        if in_progress:
+            if check_progress(line=line,
+                              update_interval_seconds=update_interval_seconds,
+                              details=details,
+                              progress_details=progress_details):
+                continue
+            if line.startswith(S_OK_OUT_COLLECTED):
+                in_progress = False
+                if verbose:
+                    logger.debug("Found end of simulation calculation line")
+                continue
+        else:
+            if line.startswith(S_OK_OUT_IN_PROGRESS):
+                in_progress = True
+                if verbose:
+                    logger.debug("Found progress line")
+                continue
+            if line.startswith(S_OK_OUT_START):
+                logger.debug("Found start of the simulation")
+                continue
+            if S_OK_OUT_FIN_PRE_CHECK in line and re.match(S_OK_OUT_FIN_PATTERN, line):
+                logger.debug("Found end of the simulation")
+                logger.info("Parsing log file for task %s finished", details.task_id)
+                up_dict = {
+                    "simulated_primaries": progress_details.requested_primaries,
+                    "end_time": utc_without_offset(progress_details.utc_now),
+                    "task_state": EntityState.COMPLETED.value
+                }
+                logger.info("Sending final update for task %d, simulated primaries %d", details.task_id,
+                            progress_details.requested_primaries)
+                send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
                 return
-            progress_details.utc_now = time_now_utc()
-            if in_progress:
-                if check_progress(line=line,
-                                  update_interval_seconds=update_interval_seconds,
-                                  details=details,
-                                  progress_details=progress_details):
-                    continue
-                if line.startswith(S_OK_OUT_COLLECTED):
-                    in_progress = False
-                    if verbose:
-                        logger.debug("Found end of simulation calculation line")
-                    continue
-            else:
-                if line.startswith(S_OK_OUT_IN_PROGRESS):
-                    in_progress = True
-                    if verbose:
-                        logger.debug("Found progress line")
-                    continue
-                if line.startswith(S_OK_OUT_START):
-                    logger.debug("Found start of the simulation")
-                    continue
-                if S_OK_OUT_FIN_PRE_CHECK in line and re.match(S_OK_OUT_FIN_PATTERN, line):
-                    logger.debug("Found end of the simulation")
-                    logger.info("Parsing log file for task %s finished", details.task_id)
-                    up_dict = {
-                        "simulated_primaries": progress_details.requested_primaries,
-                        "end_time": utc_without_offset(progress_details.utc_now),
-                        "task_state": EntityState.COMPLETED.value
-                    }
-                    logger.info("Sending final update for task %d, simulated primaries %d", details.task_id,
-                                progress_details.requested_primaries)
-                    send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
-                    return
-    except TimeoutError as err:
-        logger.error("Simulation watcher %s timed out: %s", details.task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": time_now_utc().isoformat(sep=" ")}
-        send_task_update(details.simulation_id, details.task_id, details.update_key, up_dict)
-        return
 
-    raise RuntimeError(
-        f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. "
-        "This should never happen."
-    )
+    raise RuntimeError(f"Log stream ended without completion markers in FLUKA monitor for task {details.task_id}. "
+                       "This should never happen.")

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -13,10 +13,8 @@ from pymchelper.executor.options import SimulationSettings, SimulatorType
 from pymchelper.executor.runner import Runner
 from pymchelper.input_output import frompattern
 
-from yaptide.batch.watcher import (COMPLETE_MATCH, REQUESTED_MATCH, RUN_MATCH,
-                                   TIMEOUT_MATCH, log_generator)
-from yaptide.celery.utils.progress.fluka_monitor import (TaskDetails,
-                                                         read_fluka_out_file)
+from yaptide.batch.watcher import (COMPLETE_MATCH, REQUESTED_MATCH, RUN_MATCH, TIMEOUT_MATCH, log_generator)
+from yaptide.celery.utils.progress.fluka_monitor import (TaskDetails, read_fluka_out_file)
 from yaptide.celery.utils.requests import send_task_update
 from yaptide.utils.enums import EntityState
 
@@ -197,24 +195,24 @@ def average_estimators(base_list: list[dict], list_to_add: list[dict], averaged_
 
 
 def read_shieldhit_file(event: threading.Event,
-              filepath: Path,
-              simulation_id: int,
-              task_id: str,
-              update_key: str,
-              max_wait_for_file_seconds: float = 20,
-              max_idle_seconds: float = 5 * 60,
-              update_interval_seconds: float = 2,
-              polling_interval_seconds: float = 1,
-              logging_level: int = logging.WARNING):
+                        filepath: Path,
+                        simulation_id: int,
+                        task_id: str,
+                        update_key: str,
+                        max_wait_for_file_seconds: float = 20,
+                        max_idle_seconds: float = 5 * 60,
+                        update_interval_seconds: float = 2,
+                        polling_interval_seconds: float = 1,
+                        logging_level: int = logging.WARNING):
     """
     Monitors log file of a shieldhit task, when new line with message matching regex appears, sends update to backend
-    
+
     Args:
-        max_wait_for_file_seconds: Maximum time to wait for the log file to be created 
+        max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
         update_interval_seconds: Minimum interval between successive updates to the backend.
-        polling_interval_seconds: Interval between successive file polls while no new 
+        polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
     """
     logging.getLogger(__name__).setLevel(logging_level)
@@ -224,7 +222,7 @@ def read_shieldhit_file(event: threading.Event,
 
     open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
     # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
-    for i in range(open_file_attempts): 
+    for i in range(open_file_attempts):
         if event.is_set():
             return
         try:
@@ -245,11 +243,10 @@ def read_shieldhit_file(event: threading.Event,
 
     # create generator which waits for new lines in log file
     # if no new line appears in max_idle_seconds, generator stops
-    loglines = log_generator(
-        logfile, 
-        event, 
-        max_idle_seconds=max_idle_seconds, 
-        polling_interval_seconds=polling_interval_seconds)
+    loglines = log_generator(logfile,
+                             event,
+                             max_idle_seconds=max_idle_seconds,
+                             polling_interval_seconds=polling_interval_seconds)
     requested_primaries = 0
     logging.info("Parsing log file for task %d started", task_id)
     simulated_primaries = 0
@@ -265,7 +262,8 @@ def read_shieldhit_file(event: threading.Event,
                 simulated_primaries = int(splitted[3])
             except (IndexError, ValueError):
                 logging.error("Cannot parse number of simulated primaries in line: %s", line.rstrip())
-            if (utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds  # do not send update too often
+            if (utc_now.timestamp() - last_update_timestamp_seconds <
+                    update_interval_seconds  # do not send update too often
                     and requested_primaries >= simulated_primaries):
                 logging.debug("Skipping update for task %d", task_id)
                 continue
@@ -325,13 +323,13 @@ def read_fluka_file(event: threading.Event,
                     logging_level: int = logging.WARNING):
     """
     Monitors log file of a fluka task, when new line with message matching regex appears, sends update to backend
-    
+
     Args:
-        max_wait_for_file_seconds: Maximum time to wait for the log file to be created 
+        max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
         update_interval_seconds: Minimum interval between successive updates to the backend.
-        polling_interval_seconds: Interval between successive file polls while no new 
+        polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
     """
     logging.getLogger(__name__).setLevel(logging_level)
@@ -371,11 +369,10 @@ def read_fluka_file(event: threading.Event,
 
     # create generator which waits for new lines in log file
     # if no new line appears in max_idle_seconds, generator stops
-    loglines = log_generator(
-        logfile, 
-        event, 
-        max_idle_seconds=max_idle_seconds,
-        polling_interval_seconds=polling_interval_seconds)
+    loglines = log_generator(logfile,
+                             event,
+                             max_idle_seconds=max_idle_seconds,
+                             polling_interval_seconds=polling_interval_seconds)
     logging.info("Parsing log file for task %d started", task_id)
     read_fluka_out_file(event,
                         loglines,

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import tempfile
 import threading
-import time
+import math
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Protocol
@@ -196,32 +196,46 @@ def average_estimators(base_list: list[dict], list_to_add: list[dict], averaged_
     return base_list
 
 
-def read_file(event: threading.Event,
+def read_shieldhit_file(event: threading.Event,
               filepath: Path,
               simulation_id: int,
               task_id: str,
               update_key: str,
-              timeout_wait_for_file: int = 20,
-              timeout_wait_for_line: int = 5 * 60,
-              next_backend_update_time: int = 2,
+              max_wait_for_file_seconds: float = 20,
+              max_idle_seconds: float = 5 * 60,
+              update_interval_seconds: float = 2,
+              polling_interval_seconds: float = 1,
               logging_level: int = logging.WARNING):
-    """Monitors log file of certain task, when new line with message matching regex appears, sends update to backend"""
+    """
+    Monitors log file of a shieldhit task, when new line with message matching regex appears, sends update to backend
+    
+    Args:
+        max_wait_for_file_seconds: Maximum time to wait for the log file to be created 
+            before marking the task as FAILED.
+        max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
+        update_interval_seconds: Minimum interval between successive updates to the backend.
+        polling_interval_seconds: Interval between successive file polls while no new 
+            data is available or while waiting for the file to be created.
+    """
     logging.getLogger(__name__).setLevel(logging_level)
     logfile = None
-    update_time = 0
+    last_update_timestamp_seconds = 0
     logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
-    # if the logfile is not created in the first X seconds, it is probably an error
-    for i in range(timeout_wait_for_file):  # maximum attempts, each attempt is one second
+
+    open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
+    # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
+    for i in range(open_file_attempts): 
         if event.is_set():
             return
         try:
-            logging.debug("Trying to open file %s, attempt %d/%d", filepath, i, timeout_wait_for_file)
+            logging.debug("Trying to open file %s, attempt %d/%d", filepath, i, open_file_attempts)
             logfile = open(filepath)  # skipcq: PTC-W6004
             break
         except FileNotFoundError:
-            time.sleep(1)
+            if event.wait(polling_interval_seconds):
+                return
 
-    # if logfile was not created in the first minute, task is marked as failed
+    # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
     if logfile is None:
         logging.error("Log file for task %d not found", task_id)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
@@ -230,8 +244,12 @@ def read_file(event: threading.Event,
     logging.debug("Log file for task %d found", task_id)
 
     # create generator which waits for new lines in log file
-    # if no new line appears in timeout_wait_for_line seconds, generator stops
-    loglines = log_generator(logfile, event, timeout=timeout_wait_for_line)
+    # if no new line appears in max_idle_seconds, generator stops
+    loglines = log_generator(
+        logfile, 
+        event, 
+        max_idle_seconds=max_idle_seconds, 
+        polling_interval_seconds=polling_interval_seconds)
     requested_primaries = 0
     logging.info("Parsing log file for task %d started", task_id)
     simulated_primaries = 0
@@ -247,11 +265,11 @@ def read_file(event: threading.Event,
                 simulated_primaries = int(splitted[3])
             except (IndexError, ValueError):
                 logging.error("Cannot parse number of simulated primaries in line: %s", line.rstrip())
-            if (utc_now.timestamp() - update_time < next_backend_update_time  # do not send update too often
+            if (utc_now.timestamp() - last_update_timestamp_seconds < update_interval_seconds  # do not send update too often
                     and requested_primaries >= simulated_primaries):
                 logging.debug("Skipping update for task %d", task_id)
                 continue
-            update_time = utc_now.timestamp()
+            last_update_timestamp_seconds = utc_now.timestamp()
             estimated_seconds = 0
             try:
                 estimated_seconds = int(splitted[9]) + int(splitted[7]) * 60 + int(splitted[5]) * 3600
@@ -300,36 +318,50 @@ def read_fluka_file(event: threading.Event,
                     simulation_id: int,
                     task_id: int,
                     update_key: str,
-                    timeout_wait_for_file_s: int = 20,
-                    timeout_wait_for_line_s: int = 5 * 60,
-                    next_backend_update_time_s: int = 2,
+                    max_wait_for_file_seconds: float = 20,
+                    max_idle_seconds: float = 5 * 60,
+                    update_interval_seconds: float = 2,
+                    polling_interval_seconds: float = 1,
                     logging_level: int = logging.WARNING):
-    """Monitors log file of fluka task"""
+    """
+    Monitors log file of a fluka task, when new line with message matching regex appears, sends update to backend
+    
+    Args:
+        max_wait_for_file_seconds: Maximum time to wait for the log file to be created 
+            before marking the task as FAILED.
+        max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
+        update_interval_seconds: Minimum interval between successive updates to the backend.
+        polling_interval_seconds: Interval between successive file polls while no new 
+            data is available or while waiting for the file to be created.
+    """
     logging.getLogger(__name__).setLevel(logging_level)
     logfile = None
     logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
 
-    # if the logfile is not created in the first X seconds, it is probably an error
+    # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
     # continuation of awful glob path hack
     def get_first_matching_file() -> Optional[Path]:
         """Returns first matching file."""
         path = next(dirpath.glob("fluka_*/*001.out"), None)
         return path.resolve() if path else None
 
-    for _ in range(timeout_wait_for_file_s):  # maximum attempts, each attempt is one second
+    open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
+    for _ in range(open_file_attempts):
         if event.is_set():
             return
         try:
             optional_file = get_first_matching_file()
             if not optional_file:
-                time.sleep(1)
+                if event.wait(polling_interval_seconds):
+                    return
                 continue
             logfile = open(optional_file)  # skipcq: PTC-W6004
             break
         except FileNotFoundError:
-            time.sleep(1)
+            if event.wait(polling_interval_seconds):
+                return
 
-    # if logfile was not created in the first minute, task is marked as failed
+    # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
     if logfile is None:
         logging.error("Log file for task %d not found", task_id)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
@@ -338,12 +370,16 @@ def read_fluka_file(event: threading.Event,
     logging.debug("Log file for task %d found", task_id)
 
     # create generator which waits for new lines in log file
-    # if no new line appears in timeout_wait_for_line seconds, generator stops
-    loglines = log_generator(logfile, event, timeout=timeout_wait_for_line_s)
+    # if no new line appears in max_idle_seconds, generator stops
+    loglines = log_generator(
+        logfile, 
+        event, 
+        max_idle_seconds=max_idle_seconds,
+        polling_interval_seconds=polling_interval_seconds)
     logging.info("Parsing log file for task %d started", task_id)
     read_fluka_out_file(event,
                         loglines,
-                        next_backend_update_time=next_backend_update_time_s,
+                        update_interval_seconds=update_interval_seconds,
                         details=TaskDetails(simulation_id, task_id, update_key),
                         verbose=logging_level <= logging.INFO)
 

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -13,7 +13,7 @@ from pymchelper.executor.options import SimulationSettings, SimulatorType
 from pymchelper.executor.runner import Runner
 from pymchelper.input_output import frompattern
 
-from yaptide.batch.watcher import (COMPLETE_MATCH, REQUESTED_MATCH, RUN_MATCH, TIMEOUT_MATCH, log_generator)
+from yaptide.batch.watcher import (COMPLETE_MATCH, REQUESTED_MATCH, RUN_MATCH, log_generator)
 from yaptide.celery.utils.progress.fluka_monitor import (TaskDetails, read_fluka_out_file)
 from yaptide.celery.utils.requests import send_task_update
 from yaptide.utils.enums import EntityState
@@ -258,65 +258,65 @@ def read_shieldhit_file(event: threading.Event,
     requested_primaries = 0
     logging.info("Parsing log file for task %d started", task_id)
     simulated_primaries = 0
-    for line in loglines:
-        if event.is_set():
-            return
-        utc_now = datetime.utcnow()
-        logging.debug("Parsing line: %s", line.rstrip())
-        if re.search(RUN_MATCH, line):
-            logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath, task_id)
-            splitted = line.split()
-            try:
-                simulated_primaries = int(splitted[3])
-            except (IndexError, ValueError):
-                logging.error("Cannot parse number of simulated primaries in line: %s", line.rstrip())
-            if (utc_now.timestamp() - last_update_timestamp_seconds <
-                    update_interval_seconds  # do not send update too often
-                    and requested_primaries >= simulated_primaries):
-                logging.debug("Skipping update for task %d", task_id)
-                continue
-            last_update_timestamp_seconds = utc_now.timestamp()
-            estimated_seconds = 0
-            try:
-                estimated_seconds = int(splitted[9]) + int(splitted[7]) * 60 + int(splitted[5]) * 3600
-            except (IndexError, ValueError):
-                logging.error("Cannot parse estimated time in line: %s", line.rstrip())
-            up_dict = {"simulated_primaries": simulated_primaries, "estimated_time": estimated_seconds}
-            logging.debug("Sending update for task %d, simulated primaries %d", task_id, simulated_primaries)
-            send_task_update(simulation_id, task_id, update_key, up_dict)
+    try:
+        for line in loglines:
+            if event.is_set():
+                return
+            utc_now = datetime.utcnow()
+            logging.debug("Parsing line: %s", line.rstrip())
+            if re.search(RUN_MATCH, line):
+                logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath, task_id)
+                splitted = line.split()
+                try:
+                    simulated_primaries = int(splitted[3])
+                except (IndexError, ValueError):
+                    logging.error("Cannot parse number of simulated primaries in line: %s", line.rstrip())
+                if (utc_now.timestamp() - last_update_timestamp_seconds <
+                        update_interval_seconds  # do not send update too often
+                        and requested_primaries >= simulated_primaries):
+                    logging.debug("Skipping update for task %d", task_id)
+                    continue
+                last_update_timestamp_seconds = utc_now.timestamp()
+                estimated_seconds = 0
+                try:
+                    estimated_seconds = int(splitted[9]) + int(splitted[7]) * 60 + int(splitted[5]) * 3600
+                except (IndexError, ValueError):
+                    logging.error("Cannot parse estimated time in line: %s", line.rstrip())
+                up_dict = {"simulated_primaries": simulated_primaries, "estimated_time": estimated_seconds}
+                logging.debug("Sending update for task %d, simulated primaries %d", task_id, simulated_primaries)
+                send_task_update(simulation_id, task_id, update_key, up_dict)
 
-        elif re.search(REQUESTED_MATCH, line):
-            logging.debug("Found REQUESTED_MATCH in line: %s for file: %s and task: %d ", line, filepath, task_id)
-            # found a line with requested primaries, update database
-            # task is in RUNNING state
-            splitted = line.split(": ")
-            requested_primaries = int(splitted[1])
-            up_dict = {
-                "simulated_primaries": 0,
-                "start_time": utc_now.isoformat(sep=" "),
-                "task_state": EntityState.RUNNING.value
-            }
-            logging.debug("Sending update for task %d", task_id)
-            send_task_update(simulation_id, task_id, update_key, up_dict)
+            elif re.search(REQUESTED_MATCH, line):
+                logging.debug("Found REQUESTED_MATCH in line: %s for file: %s and task: %d ", line, filepath, task_id)
+                # found a line with requested primaries, update database
+                # task is in RUNNING state
+                splitted = line.split(": ")
+                requested_primaries = int(splitted[1])
+                up_dict = {
+                    "simulated_primaries": 0,
+                    "start_time": utc_now.isoformat(sep=" "),
+                    "task_state": EntityState.RUNNING.value
+                }
+                logging.debug("Sending update for task %d", task_id)
+                send_task_update(simulation_id, task_id, update_key, up_dict)
+            elif re.search(COMPLETE_MATCH, line):
+                logging.debug("Found COMPLETE_MATCH in line: %s for file: %s and task: %d ", line, filepath, task_id)
+                logging.info("Parsing log file for task %d finished", task_id)
+                up_dict = {
+                    "simulated_primaries": simulated_primaries,
+                    "end_time": utc_now.isoformat(sep=" "),
+                    "task_state": EntityState.COMPLETED.value
+                }
+                logging.info("Sending final update for task %d, simulated primaries %d", task_id, simulated_primaries)
+                send_task_update(simulation_id, task_id, update_key, up_dict)
+                return
+    except TimeoutError as err:
+        logging.error("Simulation watcher %d timed out: %s", task_id, err)
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
+        send_task_update(simulation_id, task_id, update_key, up_dict)
+        return
 
-        elif re.search(TIMEOUT_MATCH, line):
-            logging.error("Simulation watcher %d timed out", task_id)
-            up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
-            send_task_update(simulation_id, task_id, update_key, up_dict)
-            return
-
-        elif re.search(COMPLETE_MATCH, line):
-            logging.debug("Found COMPLETE_MATCH in line: %s for file: %s and task: %d ", line, filepath, task_id)
-            break
-
-    logging.info("Parsing log file for task %d finished", task_id)
-    up_dict = {
-        "simulated_primaries": simulated_primaries,
-        "end_time": utc_now.isoformat(sep=" "),
-        "task_state": EntityState.COMPLETED.value
-    }
-    logging.info("Sending final update for task %d, simulated primaries %d", task_id, simulated_primaries)
-    send_task_update(simulation_id, task_id, update_key, up_dict)
+    raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen.")
 
 
 def read_fluka_file(event: threading.Event,

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -246,10 +246,7 @@ def read_shieldhit_file(event: threading.Event,
         # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
         if logfile is None:
             logging.error("Log file for task %d not found", task_id)
-            up_dict = {
-                "task_state": EntityState.FAILED.value,
-                "end_time": datetime.utcnow().isoformat(sep=" ")
-            }
+            up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
             send_task_update(simulation_id, task_id, update_key, up_dict)
             return
         logging.debug("Log file for task %d found", task_id)
@@ -317,8 +314,9 @@ def read_shieldhit_file(event: threading.Event,
                 send_task_update(simulation_id, task_id, update_key, up_dict)
                 return
 
-        raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
-                           f"This should never happen.")
+        if not event.is_set():
+            raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
+                               f"This should never happen.")
     except TimeoutError as err:
         logging.error("Simulation watcher %d timed out: %s", task_id, err)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
@@ -389,10 +387,7 @@ def read_fluka_file(event: threading.Event,
         # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
         if logfile is None:
             logging.error("Log file for task %d not found", task_id)
-            up_dict = {
-                "task_state": EntityState.FAILED.value,
-                "end_time": datetime.utcnow().isoformat(sep=" ")
-            }
+            up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
             send_task_update(simulation_id, task_id, update_key, up_dict)
             return
         logging.debug("Log file for task %d found", task_id)

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -325,6 +325,9 @@ def read_shieldhit_file(event: threading.Event,
         logging.error("Error while monitoring log file for task %d: %s", task_id, err)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
+    finally:
+        if logfile is not None:
+            logfile.close()
 
 
 def read_fluka_file(event: threading.Event,
@@ -412,6 +415,9 @@ def read_fluka_file(event: threading.Event,
         logging.error("Error while monitoring log file for task %d: %s", task_id, err)
         up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
+    finally:
+        if logfile is not None:
+            logfile.close()
 
 
 def read_file_offline(filepath: Path) -> tuple[int, int]:

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import threading
 import math
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Protocol
 

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -248,7 +248,7 @@ def read_shieldhit_file(event: threading.Event,
             logging.error("Log file for task %d not found", task_id)
             up_dict = {
                 "task_state": EntityState.FAILED.value,
-                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+                "end_time": datetime.utcnow().isoformat(sep=" ")
             }
             send_task_update(simulation_id, task_id, update_key, up_dict)
             return
@@ -267,7 +267,7 @@ def read_shieldhit_file(event: threading.Event,
         for line in loglines:
             if event.is_set():
                 return
-            utc_now = datetime.now(timezone.utc)
+            utc_now = datetime.utcnow()
             logging.debug("Parsing line: %s", line.rstrip())
             if re.search(RUN_MATCH, line):
                 logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath,
@@ -321,11 +321,11 @@ def read_shieldhit_file(event: threading.Event,
                            f"This should never happen.")
     except TimeoutError as err:
         logging.error("Simulation watcher %d timed out: %s", task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
     except Exception as err:  # skipcq: PYL-W0703
         logging.error("Error while monitoring log file for task %d: %s", task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
 
 
@@ -391,7 +391,7 @@ def read_fluka_file(event: threading.Event,
             logging.error("Log file for task %d not found", task_id)
             up_dict = {
                 "task_state": EntityState.FAILED.value,
-                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+                "end_time": datetime.utcnow().isoformat(sep=" ")
             }
             send_task_update(simulation_id, task_id, update_key, up_dict)
             return
@@ -411,11 +411,11 @@ def read_fluka_file(event: threading.Event,
                             verbose=logging_level <= logging.INFO)
     except TimeoutError as err:
         logging.error("Simulation watcher %d timed out: %s", task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
     except Exception as err:  # skipcq: PYL-W0703
         logging.error("Error while monitoring log file for task %d: %s", task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
 
 

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -194,6 +194,7 @@ def average_estimators(base_list: list[dict], list_to_add: list[dict], averaged_
     return base_list
 
 
+# skipcq:  PY-R1000
 def read_shieldhit_file(event: threading.Event,
                         filepath: Path,
                         simulation_id: int,
@@ -203,11 +204,11 @@ def read_shieldhit_file(event: threading.Event,
                         max_idle_seconds: float = 5 * 60,
                         update_interval_seconds: float = 2,
                         polling_interval_seconds: float = 1,
-                        logging_level: int = logging.WARNING): # skipcq:  PY-R1000
+                        logging_level: int = logging.WARNING):
     """
     Monitors log file of a shieldhit task, when new line with message matching regex appears, sends update to backend
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
-    
+
     Args:
         event: Threading event to signal when to stop monitoring.
         filepath: Path to the log file to monitor.
@@ -331,7 +332,7 @@ def read_fluka_file(event: threading.Event,
     """
     Monitors log file of a fluka task, when new line with message matching regex appears, sends update to backend
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
-    
+
     Args:
         event: Threading event to signal when to stop monitoring.
         dirpath: Path to the directory containing the log file to monitor.

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -209,12 +209,18 @@ def read_shieldhit_file(event: threading.Event,
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
     
     Args:
+        event: Threading event to signal when to stop monitoring.
+        filepath: Path to the log file to monitor.
+        simulation_id: Simulation ID.
+        task_id: Task ID.
+        update_key: Simulation auth token for backend updates.
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
         update_interval_seconds: Minimum interval between successive updates to the backend.
         polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
+        logging_level: Logging level to use for monitoring logs.
     """
     logging.getLogger(__name__).setLevel(logging_level)
     logfile = None
@@ -327,12 +333,18 @@ def read_fluka_file(event: threading.Event,
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
     
     Args:
+        event: Threading event to signal when to stop monitoring.
+        dirpath: Path to the directory containing the log file to monitor.
+        simulation_id: Simulation ID.
+        task_id: Task ID.
+        update_key: Simulation auth token for backend updates.
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
         max_idle_seconds: Maximum time to wait for new data before marking the task as FAILED.
         update_interval_seconds: Minimum interval between successive updates to the backend.
         polling_interval_seconds: Interval between successive file polls while no new
             data is available or while waiting for the file to be created.
+        logging_level: Logging level to use for monitoring logs.
     """
     logging.getLogger(__name__).setLevel(logging_level)
     logfile = None

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -318,7 +318,8 @@ def read_shieldhit_file(event: threading.Event,
         return
 
     raise RuntimeError(
-        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen."
+        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
+        f"This should never happen."
     )
 
 

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -203,10 +203,11 @@ def read_shieldhit_file(event: threading.Event,
                         max_idle_seconds: float = 5 * 60,
                         update_interval_seconds: float = 2,
                         polling_interval_seconds: float = 1,
-                        logging_level: int = logging.WARNING):
+                        logging_level: int = logging.WARNING): # skipcq:  PY-R1000
     """
     Monitors log file of a shieldhit task, when new line with message matching regex appears, sends update to backend
-
+    The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
+    
     Args:
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.
@@ -323,7 +324,8 @@ def read_fluka_file(event: threading.Event,
                     logging_level: int = logging.WARNING):
     """
     Monitors log file of a fluka task, when new line with message matching regex appears, sends update to backend
-
+    The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
+    
     Args:
         max_wait_for_file_seconds: Maximum time to wait for the log file to be created
             before marking the task as FAILED.

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -76,7 +76,7 @@ def get_shieldhit_estimators(dir_path: Path) -> dict:
     return estimators_dict
 
 
-def command_to_run_fluka(dir_path: Path, task_id: str) -> list[str]:
+def command_to_run_fluka(dir_path: Path, task_id: int) -> list[str]:
     """Function to create command to run FLUKA."""
     input_file = next(dir_path.glob("*.inp"), None)
     if input_file is None:
@@ -198,7 +198,7 @@ def average_estimators(base_list: list[dict], list_to_add: list[dict], averaged_
 def read_shieldhit_file(event: threading.Event,
                         filepath: Path,
                         simulation_id: int,
-                        task_id: str,
+                        task_id: int,
                         update_key: str,
                         max_wait_for_file_seconds: float = 20,
                         max_idle_seconds: float = 5 * 60,

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import threading
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Protocol
 
@@ -208,6 +208,7 @@ def read_shieldhit_file(event: threading.Event,
     """
     Monitors log file of a shieldhit task, when new line with message matching regex appears, sends update to backend
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
+    All possible exceptions are caught and logged, and in case of any exception the task is marked as FAILED.
 
     Args:
         event: Threading event to signal when to stop monitoring.
@@ -223,46 +224,50 @@ def read_shieldhit_file(event: threading.Event,
             data is available or while waiting for the file to be created.
         logging_level: Logging level to use for monitoring logs.
     """
-    logging.getLogger(__name__).setLevel(logging_level)
-    logfile = None
-    last_update_timestamp_seconds = 0
-    logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
-
-    open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
-    # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
-    for i in range(open_file_attempts):
-        if event.is_set():
-            return
-        try:
-            logging.debug("Trying to open file %s, attempt %d/%d", filepath, i, open_file_attempts)
-            logfile = open(filepath)  # skipcq: PTC-W6004
-            break
-        except FileNotFoundError:
-            if event.wait(polling_interval_seconds):
-                return
-
-    # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
-    if logfile is None:
-        logging.error("Log file for task %d not found", task_id)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
-        send_task_update(simulation_id, task_id, update_key, up_dict)
-        return
-    logging.debug("Log file for task %d found", task_id)
-
-    # create generator which waits for new lines in log file
-    # if no new line appears in max_idle_seconds, generator stops
-    loglines = log_generator(logfile,
-                             event,
-                             max_idle_seconds=max_idle_seconds,
-                             polling_interval_seconds=polling_interval_seconds)
-    requested_primaries = 0
-    logging.info("Parsing log file for task %d started", task_id)
-    simulated_primaries = 0
     try:
+        logging.getLogger(__name__).setLevel(logging_level)
+        logfile = None
+        last_update_timestamp_seconds = 0
+        logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
+
+        open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
+        # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
+        for i in range(open_file_attempts):
+            if event.is_set():
+                return
+            try:
+                logging.debug("Trying to open file %s, attempt %d/%d", filepath, i, open_file_attempts)
+                logfile = open(filepath)  # skipcq: PTC-W6004
+                break
+            except FileNotFoundError:
+                if event.wait(polling_interval_seconds):
+                    return
+
+        # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
+        if logfile is None:
+            logging.error("Log file for task %d not found", task_id)
+            up_dict = {
+                "task_state": EntityState.FAILED.value,
+                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+            }
+            send_task_update(simulation_id, task_id, update_key, up_dict)
+            return
+        logging.debug("Log file for task %d found", task_id)
+
+        # create generator which waits for new lines in log file
+        # if no new line appears in max_idle_seconds, generator stops
+        loglines = log_generator(logfile,
+                                 event,
+                                 max_idle_seconds=max_idle_seconds,
+                                 polling_interval_seconds=polling_interval_seconds)
+        requested_primaries = 0
+        logging.info("Parsing log file for task %d started", task_id)
+        simulated_primaries = 0
+
         for line in loglines:
             if event.is_set():
                 return
-            utc_now = datetime.utcnow()
+            utc_now = datetime.now(timezone.utc)
             logging.debug("Parsing line: %s", line.rstrip())
             if re.search(RUN_MATCH, line):
                 logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath,
@@ -311,16 +316,17 @@ def read_shieldhit_file(event: threading.Event,
                 logging.info("Sending final update for task %d, simulated primaries %d", task_id, simulated_primaries)
                 send_task_update(simulation_id, task_id, update_key, up_dict)
                 return
+
+        raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
+                           f"This should never happen.")
     except TimeoutError as err:
         logging.error("Simulation watcher %d timed out: %s", task_id, err)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
-        return
-
-    raise RuntimeError(
-        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. "
-        f"This should never happen."
-    )
+    except Exception as err:  # skipcq: PYL-W0703
+        logging.error("Error while monitoring log file for task %d: %s", task_id, err)
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        send_task_update(simulation_id, task_id, update_key, up_dict)
 
 
 def read_fluka_file(event: threading.Event,
@@ -336,6 +342,7 @@ def read_fluka_file(event: threading.Event,
     """
     Monitors log file of a fluka task, when new line with message matching regex appears, sends update to backend
     The purpose of the updates is the progress bar update and state updates (like simulation failed or completed).
+    All possible exceptions are caught and logged, and in case of any exception the task is marked as FAILED.
 
     Args:
         event: Threading event to signal when to stop monitoring.
@@ -351,53 +358,65 @@ def read_fluka_file(event: threading.Event,
             data is available or while waiting for the file to be created.
         logging_level: Logging level to use for monitoring logs.
     """
-    logging.getLogger(__name__).setLevel(logging_level)
-    logfile = None
-    logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
+    try:
+        logging.getLogger(__name__).setLevel(logging_level)
+        logfile = None
+        logging.info("Started monitoring, simulation id: %d, task id: %d", simulation_id, task_id)
 
-    # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
-    # continuation of awful glob path hack
-    def get_first_matching_file() -> Optional[Path]:
-        """Returns first matching file."""
-        path = next(dirpath.glob("fluka_*/*001.out"), None)
-        return path.resolve() if path else None
+        # if the logfile is not created in the first max_wait_for_file_seconds, it is probably an error
+        # continuation of awful glob path hack
+        def get_first_matching_file() -> Optional[Path]:
+            """Returns first matching file."""
+            path = next(dirpath.glob("fluka_*/*001.out"), None)
+            return path.resolve() if path else None
 
-    open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
-    for _ in range(open_file_attempts):
-        if event.is_set():
-            return
-        try:
-            optional_file = get_first_matching_file()
-            if not optional_file:
+        open_file_attempts = math.ceil(max_wait_for_file_seconds / polling_interval_seconds)
+        for _ in range(open_file_attempts):
+            if event.is_set():
+                return
+            try:
+                optional_file = get_first_matching_file()
+                if not optional_file:
+                    if event.wait(polling_interval_seconds):
+                        return
+                    continue
+                logfile = open(optional_file)  # skipcq: PTC-W6004
+                break
+            except FileNotFoundError:
                 if event.wait(polling_interval_seconds):
                     return
-                continue
-            logfile = open(optional_file)  # skipcq: PTC-W6004
-            break
-        except FileNotFoundError:
-            if event.wait(polling_interval_seconds):
-                return
 
-    # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
-    if logfile is None:
-        logging.error("Log file for task %d not found", task_id)
-        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.utcnow().isoformat(sep=" ")}
+        # if logfile was not created in the first max_wait_for_file_seconds, task is marked as failed
+        if logfile is None:
+            logging.error("Log file for task %d not found", task_id)
+            up_dict = {
+                "task_state": EntityState.FAILED.value,
+                "end_time": datetime.now(timezone.utc).isoformat(sep=" ")
+            }
+            send_task_update(simulation_id, task_id, update_key, up_dict)
+            return
+        logging.debug("Log file for task %d found", task_id)
+
+        # create generator which waits for new lines in log file
+        # if no new line appears in max_idle_seconds, generator stops
+        loglines = log_generator(logfile,
+                                 event,
+                                 max_idle_seconds=max_idle_seconds,
+                                 polling_interval_seconds=polling_interval_seconds)
+        logging.info("Parsing log file for task %d started", task_id)
+        read_fluka_out_file(event,
+                            loglines,
+                            update_interval_seconds=update_interval_seconds,
+                            details=TaskDetails(simulation_id, task_id, update_key),
+                            verbose=logging_level <= logging.INFO)
+    except TimeoutError as err:
+        logging.error("Simulation watcher %d timed out: %s", task_id, err)
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
         send_task_update(simulation_id, task_id, update_key, up_dict)
-        return
-    logging.debug("Log file for task %d found", task_id)
-
-    # create generator which waits for new lines in log file
-    # if no new line appears in max_idle_seconds, generator stops
-    loglines = log_generator(logfile,
-                             event,
-                             max_idle_seconds=max_idle_seconds,
-                             polling_interval_seconds=polling_interval_seconds)
-    logging.info("Parsing log file for task %d started", task_id)
-    read_fluka_out_file(event,
-                        loglines,
-                        update_interval_seconds=update_interval_seconds,
-                        details=TaskDetails(simulation_id, task_id, update_key),
-                        verbose=logging_level <= logging.INFO)
+    except Exception as err:  # skipcq: PYL-W0703
+        logging.error("Error while monitoring log file for task %d: %s", task_id, err)
+        up_dict = {"task_state": EntityState.FAILED.value, "end_time": datetime.now(timezone.utc).isoformat(sep=" ")}
+        send_task_update(simulation_id, task_id, update_key, up_dict)
 
 
 def read_file_offline(filepath: Path) -> tuple[int, int]:

--- a/yaptide/celery/utils/pymc.py
+++ b/yaptide/celery/utils/pymc.py
@@ -265,7 +265,8 @@ def read_shieldhit_file(event: threading.Event,
             utc_now = datetime.utcnow()
             logging.debug("Parsing line: %s", line.rstrip())
             if re.search(RUN_MATCH, line):
-                logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath, task_id)
+                logging.debug("Found RUN_MATCH in line: %s for file: %s and task: %d ", line.rstrip(), filepath,
+                              task_id)
                 splitted = line.split()
                 try:
                     simulated_primaries = int(splitted[3])
@@ -316,7 +317,9 @@ def read_shieldhit_file(event: threading.Event,
         send_task_update(simulation_id, task_id, update_key, up_dict)
         return
 
-    raise RuntimeError(f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen.")
+    raise RuntimeError(
+        f"Log stream ended without completion markers in SHIELDHIT monitor for task {task_id}. This should never happen."
+    )
 
 
 def read_fluka_file(event: threading.Event,

--- a/yaptide/persistence/db_methods.py
+++ b/yaptide/persistence/db_methods.py
@@ -90,7 +90,7 @@ def fetch_simulations_by_user_id(user_id: int) -> Union[list[BatchSimulationMode
     return simulations
 
 
-def fetch_task_by_sim_id_and_task_id(sim_id: int, task_id: str) -> Union[BatchTaskModel, CeleryTaskModel]:
+def fetch_task_by_sim_id_and_task_id(sim_id: int, task_id: int) -> Union[BatchTaskModel, CeleryTaskModel]:
     """Fetches task by simulation id and task id"""
     TaskPoly = with_polymorphic(TaskModel, [BatchTaskModel, CeleryTaskModel])
     task = db.session.query(TaskPoly).filter_by(simulation_id=sim_id, task_id=task_id).first()

--- a/yaptide/routes/task_routes.py
+++ b/yaptide/routes/task_routes.py
@@ -17,7 +17,7 @@ class TasksResource(Resource):
         Structure required by this method to work properly:
         {
             "simulation_id": <int>,
-            "task_id": <string>,
+            "task_id": <int>,
             "update_key": <string>,
             "update_dict": <dict>
         }


### PR DESCRIPTION
`time.sleep()` calls were causing unnecessary delay on simulation task end.

- Replaced `time.sleep()` with `event.wait()` in functions related to task monitoring. When task ends, `event.set()` gets called so `event.wait()` exits immediately. 

- Changed names of time-related parameters to be more descriptive and added `_unit` suffix to avoid confusion (e.g. `max_idle_seconds`, `polling_interval_seconds`). In some cases the values might be lower than 1 second (e.g. polling intervals for small simulations), so I also changed the types to `float` instead of `int` (changed it for all time variables for consistency).

- Made all timeouts/intervals configurable in `read_file()` functions. Added descriptions for these parameters in docstrings to explain what each of them does in detail.

- Changed `read_file()` to `read_shieldhit_file()` for clarity (consistent with `read_fluka_file()` function).

- Changed the return type of `log_generator` from `str` to `Iterator[str]`. `Iterator` is from `collections.abc` package, which is in the standard library, so it should be fine on Ares HPC.

I ran some simulations on my pc and on the yap-dev instance to test this. Everything seems to be working as intended.