### PR TITLE
1618 - simulations with more tasks than primaries fail

### DIFF
--- a/tests/test_prepare_simulation.py
+++ b/tests/test_prepare_simulation.py
@@ -2,9 +2,10 @@
 import json
 from pathlib import Path
 import pytest
+from yaptide.utils.enums import InputType
 from yaptide.utils.sim_utils import (check_and_convert_payload_to_files_dict, convert_editor_dict_to_files_dict,
                                      adjust_primaries_in_editor_dict, adjust_primaries_in_files_dict,
-                                     write_simulation_input_files, get_json_type, JSON_TYPE)
+                                     write_simulation_input_files, get_json_type)
 from converter.api import (get_parser_from_str, run_parser)
 
 
@@ -78,8 +79,8 @@ def test_json_type_detection_editor(payload_editor_dict_data: dict):
        - containing user uploaded files (files)
     """
     json_type = get_json_type(payload_editor_dict_data)
-    assert json_type == JSON_TYPE.Editor
-    assert json_type != JSON_TYPE.Files
+    assert json_type == InputType.EDITOR
+    assert json_type != InputType.FILES
 
 
 def test_json_type_detection_files(payload_files_dict_data: dict):
@@ -89,8 +90,8 @@ def test_json_type_detection_files(payload_files_dict_data: dict):
        - containing user uploaded files (files)
     """
     json_type = get_json_type(payload_files_dict_data)
-    assert json_type != JSON_TYPE.Editor
-    assert json_type == JSON_TYPE.Files
+    assert json_type != InputType.EDITOR
+    assert json_type == InputType.FILES
 
 
 def test_if_parsing_works_for_payload(payload_editor_dict_data: dict):

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -40,7 +40,7 @@ class JobsBatch(Resource):
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
         # ensure there are at most as many tasks as primaries if using editor
-        if (input_type == "editor" && payload_dict["input_json"] is not None):
+        if (payload_dict["input_type"] == "editor" and payload_dict["input_json"] is not None):
             payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
 
         input_type = determine_input_type(payload_dict)

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -46,7 +46,6 @@ class JobsBatch(Resource):
 
         # ensure the ntasks value is in allowed range
         payload_dict["ntasks"] = get_clamped_ntasks_value(payload_dict=payload_dict,
-                                                          input_type=input_type,
                                                           ntasks=payload_dict["ntasks"])
 
         clusters = fetch_all_clusters()

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -39,6 +39,9 @@ class JobsBatch(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
+        # ensure there are at most as many tasks as primaries
+        payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
+
         input_type = determine_input_type(payload_dict)
 
         if input_type is None:

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -15,7 +15,7 @@ from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, error_internal_response,
                                                      yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict
+from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clumped_ntasks_value
 from yaptide.utils.enums import EntityState, PlatformType
 
 
@@ -39,11 +39,10 @@ class JobsBatch(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
-        # ensure there are at most as many tasks as primaries if using editor
-        if (payload_dict["input_type"] == "editor" and payload_dict["input_json"] is not None):
-            payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
-
         input_type = determine_input_type(payload_dict)
+
+        # ensure the ntasks value is in allowed range
+        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
 
         if input_type is None:
             return error_validation_response()

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -15,7 +15,8 @@ from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, error_internal_response,
                                                      yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clamped_ntasks_value
+from yaptide.routes.utils.utils import (check_if_job_is_owned_and_exist, determine_input_type,
+                                        make_input_dict, get_clamped_ntasks_value)
 from yaptide.utils.enums import EntityState, PlatformType
 
 

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -39,8 +39,9 @@ class JobsBatch(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
-        # ensure there are at most as many tasks as primaries
-        payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
+        # ensure there are at most as many tasks as primaries if using editor
+        if (input_type == "editor" && payload_dict["input_json"] is not None):
+            payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
 
         input_type = determine_input_type(payload_dict)
 

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -15,7 +15,7 @@ from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, error_internal_response,
                                                      yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clumped_ntasks_value
+from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clamped_ntasks_value
 from yaptide.utils.enums import EntityState, PlatformType
 
 
@@ -45,7 +45,9 @@ class JobsBatch(Resource):
             return error_validation_response()
 
         # ensure the ntasks value is in allowed range
-        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
+        payload_dict["ntasks"] = get_clamped_ntasks_value(payload_dict=payload_dict,
+                                                          input_type=input_type,
+                                                          ntasks=payload_dict["ntasks"])
 
         clusters = fetch_all_clusters()
         if len(clusters) < 1:

--- a/yaptide/routes/batch_routes.py
+++ b/yaptide/routes/batch_routes.py
@@ -41,11 +41,11 @@ class JobsBatch(Resource):
 
         input_type = determine_input_type(payload_dict)
 
-        # ensure the ntasks value is in allowed range
-        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
-
         if input_type is None:
             return error_validation_response()
+
+        # ensure the ntasks value is in allowed range
+        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
 
         clusters = fetch_all_clusters()
         if len(clusters) < 1:

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -17,7 +17,7 @@ from yaptide.persistence.models import (CelerySimulationModel, CeleryTaskModel, 
                                         UserModel)
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clumped_ntasks_value
+from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clamped_ntasks_value
 from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.utils.enums import EntityState, PlatformType
 from yaptide.utils.helper_tasks import terminate_unfinished_tasks
@@ -46,7 +46,9 @@ class JobsDirect(Resource):
             return error_validation_response()
 
         # ensure the ntasks value is in allowed range
-        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
+        payload_dict["ntasks"] = get_clamped_ntasks_value(payload_dict=payload_dict,
+                                                          input_type=input_type,
+                                                          ntasks=payload_dict["ntasks"])
 
         # create a new simulation in the database, not waiting for the job to finish
         job_id = datetime.now().strftime('%Y%m%d-%H%M%S-') + str(uuid4()) + PlatformType.DIRECT.value

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -40,8 +40,9 @@ class JobsDirect(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
-        # ensure there are at most as many tasks as primaries
-        payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
+        # ensure there are at most as many tasks as primaries if using editor
+        if (input_type == "editor" && payload_dict["input_json"] is not None):
+            payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
 
         input_type = determine_input_type(payload_dict)
 

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -17,7 +17,8 @@ from yaptide.persistence.models import (CelerySimulationModel, CeleryTaskModel, 
                                         UserModel)
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clamped_ntasks_value
+from yaptide.routes.utils.utils import (check_if_job_is_owned_and_exist, determine_input_type,
+                                        make_input_dict, get_clamped_ntasks_value)
 from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.utils.enums import EntityState, PlatformType
 from yaptide.utils.helper_tasks import terminate_unfinished_tasks

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -42,11 +42,11 @@ class JobsDirect(Resource):
 
         input_type = determine_input_type(payload_dict)
 
-        # ensure the ntasks value is in allowed range
-        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
-
         if input_type is None:
             return error_validation_response()
+
+        # ensure the ntasks value is in allowed range
+        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
 
         # create a new simulation in the database, not waiting for the job to finish
         job_id = datetime.now().strftime('%Y%m%d-%H%M%S-') + str(uuid4()) + PlatformType.DIRECT.value

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -41,7 +41,7 @@ class JobsDirect(Resource):
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
         # ensure there are at most as many tasks as primaries if using editor
-        if (input_type == "editor" && payload_dict["input_json"] is not None):
+        if (payload_dict["input_type"] == "editor" and payload_dict["input_json"] is not None):
             payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
 
         input_type = determine_input_type(payload_dict)

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -17,7 +17,7 @@ from yaptide.persistence.models import (CelerySimulationModel, CeleryTaskModel, 
                                         UserModel)
 from yaptide.routes.utils.decorators import requires_auth
 from yaptide.routes.utils.response_templates import (error_validation_response, yaptide_response)
-from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict
+from yaptide.routes.utils.utils import check_if_job_is_owned_and_exist, determine_input_type, make_input_dict, get_clumped_ntasks_value
 from yaptide.routes.utils.tokens import encode_simulation_auth_token
 from yaptide.utils.enums import EntityState, PlatformType
 from yaptide.utils.helper_tasks import terminate_unfinished_tasks
@@ -40,11 +40,10 @@ class JobsDirect(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
-        # ensure there are at most as many tasks as primaries if using editor
-        if (payload_dict["input_type"] == "editor" and payload_dict["input_json"] is not None):
-            payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
-
         input_type = determine_input_type(payload_dict)
+
+        # ensure the ntasks value is in allowed range
+        payload_dict["ntasks"] = get_clumped_ntasks_value(payload_dict=payload_dict, input_type=input_type)
 
         if input_type is None:
             return error_validation_response()

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -40,6 +40,9 @@ class JobsDirect(Resource):
             diff = required_keys.difference(set(payload_dict.keys()))
             return yaptide_response(message=f"Missing keys in JSON payload: {diff}", code=400)
 
+        # ensure there are at most as many tasks as primaries
+        payload_dict["ntasks"] = min(payload_dict["ntasks"], payload_dict["input_json"]["beam"]["numberOfParticles"])
+
         input_type = determine_input_type(payload_dict)
 
         if input_type is None:

--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -47,7 +47,6 @@ class JobsDirect(Resource):
 
         # ensure the ntasks value is in allowed range
         payload_dict["ntasks"] = get_clamped_ntasks_value(payload_dict=payload_dict,
-                                                          input_type=input_type,
                                                           ntasks=payload_dict["ntasks"])
 
         # create a new simulation in the database, not waiting for the job to finish

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 from yaptide.persistence.db_methods import fetch_simulation_by_job_id
 from yaptide.persistence.models import UserModel
 from yaptide.utils.enums import InputType, SimulationType
-from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries, get_primaries_file_type_and_name
+from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries, get_total_number_of_primaries
 
 
 def check_if_job_is_owned_and_exist(job_id: str, user: UserModel) -> tuple[bool, str, int]:
@@ -67,26 +67,12 @@ def get_clamped_ntasks_value(payload_dict: dict, input_type: str, ntasks: int) -
     if ntasks < 1:
         return 1
 
-    # get the number of primaries, depending on the input_type
-    if input_type == InputType.EDITOR.value:
-        number_of_all_primaries = payload_dict["input_json"]["beam"]["numberOfParticles"]
-    else:
-        file_type, file_name = get_primaries_file_type_and_name(payload_dict)
+    # get the number of primaries
+    number_of_all_primaries = get_total_number_of_primaries(payload_dict)
 
-        # if we cannot determine the file type, fallback to original ntasks
-        if not file_type:
-            return ntasks
-
-        if file_type == SimulationType.SHIELDHIT:
-            all_beam_lines: list[str] = payload_dict["input_files"][file_name].split('\n')
-            all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
-            number_of_all_primaries = int(all_beam_lines_with_nstat[0].split()[1])
-        elif file_type == SimulationType.FLUKA:
-            # read number of primaries from fluka file
-            all_input_lines: list[str] = payload_dict["input_files"][file_name].split('\n')
-            # get value from START card
-            start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
-            number_of_all_primaries = int(float(start_card.split()[1]))
+    # if we couldn't get the total number of primaries, fall back to the original ntasks value
+    if not number_of_all_primaries:
+        return ntasks
 
     # if the number of tasks is larger than the number of primaries, clamp the number of tasks to its value
     if ntasks > number_of_all_primaries:

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -44,3 +44,48 @@ def make_input_dict(payload_dict: dict, input_type: str) -> dict:
     input_dict["input_files"] = files_dict
 
     return input_dict
+
+
+def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
+    """
+    Function that validates ntasks value in a simulation and returns the number of tasks that  the simulation should use.
+    It's used to prevents simulations with ntasks outside of range [1; primaries_count].
+    The ntasks value needs to be larger than 0, because you need at least a single task to run a simulation.
+    The ntasks value also needs to be smaller than the number of primaries, because a task
+    needs at least one primary to run. If the number of tasks is larger than the number of primaries
+    then some tasks would have 0 primaries in them, which will make the simulation crash.
+
+    Args:
+        payload_dict: A dictionary containing the payload received from a request.
+        input_type: Input type determining if the request used editor or files.
+
+    Returns:
+        Integer value representing the ntasks value to use in the simulation.
+    """
+    # ensure there is at least 1 task
+    if payload_dict["ntasks"] < 1:
+        return 1
+
+    # get the number of primaries, depending on the input_type
+    if input_type == InputType.EDITOR.value:
+        number_of_all_primaries = payload_dict["input_json"]["beam"]["numberOfParticles"]
+    # ugly way of determining the file type, but that's how it's done in sim_utils
+    elif 'beam.dat' in payload_dict["input_files"]:
+        all_beam_lines: list[str] = payload_dict["input_files"]['beam.dat'].split('\n')
+        all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
+        number_of_all_primaries = int(all_beam_lines_with_nstat[0].split()[1])
+    elif next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None):
+        input_file = next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None)
+        # read number of primaries from fluka file
+        all_input_lines: list[str] = payload_dict[input_file].split('\n')
+        # get value from START card
+        start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
+        number_of_all_primaries = int(float(start_card.split()[1]))
+
+    # if the number of tasks is larger than the number of primaries, clump the number of tasks to its value
+    if payload_dict["ntasks"] > number_of_all_primaries:
+        return number_of_all_primaries
+
+    # if ntasks is within range, return the original value
+    return payload_dict["ntasks"]
+

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -74,6 +74,12 @@ def get_clamped_ntasks_value(payload_dict: dict, input_type: str, ntasks: int) -
     if not number_of_all_primaries:
         return ntasks
 
+    # if number of all primaries is less than 1, fall back to 1 task
+    # if this happens the simulation will most likely fail anyway, but it's better to check it,
+    # because it could just be incorrect read from the function above or something similar
+    if number_of_all_primaries < 1:
+        return 1
+
     # if the number of tasks is larger than the number of primaries, clamp the number of tasks to its value
     if ntasks > number_of_all_primaries:
         return number_of_all_primaries

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -50,7 +50,8 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     """
     Function that validates ntasks value in a simulation and returns the number of tasks that the simulation should use.
     It's used to prevent simulations with ntasks outside of range [1; primaries_count].
-    The ntasks value needs to be larger than 0, because you need at least a single task to run a simulation.
+    The ntasks value needs to be larger than 0, because you need at least a single task to run a simulation
+    with certain simulators (like SHIELD-HIT12A).
     The ntasks value also needs to be less than or equal to the number of primaries, because a task
     needs at least one primary to run. If the number of tasks is larger than the number of primaries
     then some tasks would have 0 primaries in them, which will make the simulation crash.
@@ -66,7 +67,7 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     if ntasks < 1:
         return 1
 
-    # get the number of primaries
+    # get the total number of primaries for the whole simulation/job
     number_of_all_primaries = get_total_number_of_primaries(payload_dict)
 
     # if we couldn't get the total number of primaries, fall back to the original ntasks value

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -70,7 +70,7 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     number_of_all_primaries = get_total_number_of_primaries(payload_dict)
 
     # if we couldn't get the total number of primaries, fall back to the original ntasks value
-    if number_of_all_primaries is not None:
+    if number_of_all_primaries is None:
         return ntasks
 
     # if number of all primaries is less than 1, fall back to 1 task

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -49,9 +49,9 @@ def make_input_dict(payload_dict: dict, input_type: str) -> dict:
 def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     """
     Function that validates ntasks value in a simulation and returns the number of tasks that the simulation should use.
-    It's used to prevents simulations with ntasks outside of range [1; primaries_count].
+    It's used to prevent simulations with ntasks outside of range [1; primaries_count].
     The ntasks value needs to be larger than 0, because you need at least a single task to run a simulation.
-    The ntasks value also needs to be smaller than the number of primaries, because a task
+    The ntasks value also needs to be less than or equal to the number of primaries, because a task
     needs at least one primary to run. If the number of tasks is larger than the number of primaries
     then some tasks would have 0 primaries in them, which will make the simulation crash.
 

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from yaptide.persistence.db_methods import fetch_simulation_by_job_id
 from yaptide.persistence.models import UserModel
-from yaptide.utils.enums import InputType
-from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
+from yaptide.utils.enums import InputType, SimulationType
+from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries, get_primaries_file_type_and_name
 
 
 def check_if_job_is_owned_and_exist(job_id: str, user: UserModel) -> tuple[bool, str, int]:
@@ -70,21 +70,23 @@ def get_clamped_ntasks_value(payload_dict: dict, input_type: str, ntasks: int) -
     # get the number of primaries, depending on the input_type
     if input_type == InputType.EDITOR.value:
         number_of_all_primaries = payload_dict["input_json"]["beam"]["numberOfParticles"]
-    # ugly way of determining the file type, but that's how it's done in sim_utils
-    elif 'beam.dat' in payload_dict["input_files"]:
-        all_beam_lines: list[str] = payload_dict["input_files"]['beam.dat'].split('\n')
-        all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
-        number_of_all_primaries = int(all_beam_lines_with_nstat[0].split()[1])
-    elif next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None):
-        input_file = next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None)
-        # read number of primaries from fluka file
-        all_input_lines: list[str] = payload_dict["input_files"][input_file].split('\n')
-        # get value from START card
-        start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
-        number_of_all_primaries = int(float(start_card.split()[1]))
-    # if we cannot determine the file type, fallback to original ntasks
     else:
-        return ntasks
+        file_type, file_name = get_primaries_file_type_and_name(payload_dict)
+
+        # if we cannot determine the file type, fallback to original ntasks
+        if not file_type:
+            return ntasks
+
+        if file_type == SimulationType.SHIELDHIT:
+            all_beam_lines: list[str] = payload_dict["input_files"][file_name].split('\n')
+            all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
+            number_of_all_primaries = int(all_beam_lines_with_nstat[0].split()[1])
+        elif file_type == SimulationType.FLUKA:
+            # read number of primaries from fluka file
+            all_input_lines: list[str] = payload_dict["input_files"][file_name].split('\n')
+            # get value from START card
+            start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
+            number_of_all_primaries = int(float(start_card.split()[1]))
 
     # if the number of tasks is larger than the number of primaries, clamp the number of tasks to its value
     if ntasks > number_of_all_primaries:

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -65,6 +65,7 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     """
     # ensure there is at least 1 task
     if ntasks < 1:
+        logging.warning("Received %d as the ntasks value. The value shouldn't be less than 1. Clamping to 1.", ntasks)
         return 1
 
     # get the total number of primaries for the whole simulation/job
@@ -72,6 +73,8 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
 
     # if we couldn't get the total number of primaries, fall back to the original ntasks value
     if number_of_all_primaries is None:
+        logging.warning("Could not determine the total number of primaries from the payload.\
+                         Therefore we cannot validate the ntasks value. Using the received value without validation.")
         return ntasks
 
     # if number of all primaries is less than 1, fall back to 1 task
@@ -82,6 +85,11 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
 
     # if the number of tasks is larger than the number of primaries, clamp the number of tasks to its value
     if ntasks > number_of_all_primaries:
+        logging.warning("The received ntasks value is %d and the determined number of all primaries is %d.\
+                         To avoid simulation crashing by having tasks with 0 primaries, the number of tasks\
+                         should be less than or equal to the number of all primaries.\
+                         Clamping ntasks value to the number of all primaries.",
+                        ntasks, number_of_all_primaries)
         return number_of_all_primaries
 
     # if ntasks is within range, return the original value

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -57,7 +57,6 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
 
     Args:
         payload_dict: A dictionary containing the payload received from a request.
-        input_type: Input type determining if the request used editor or files.
         ntasks: Task count from the request to be clamped
 
     Returns:

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import logging
 
 from yaptide.persistence.db_methods import fetch_simulation_by_job_id
 from yaptide.persistence.models import UserModel

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -86,4 +86,3 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
 
     # if ntasks is within range, return the original value
     return ntasks
-

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from yaptide.persistence.db_methods import fetch_simulation_by_job_id
 from yaptide.persistence.models import UserModel
-from yaptide.utils.enums import InputType, SimulationType
+from yaptide.utils.enums import InputType
 from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries, get_total_number_of_primaries
 
 
@@ -46,7 +46,7 @@ def make_input_dict(payload_dict: dict, input_type: str) -> dict:
     return input_dict
 
 
-def get_clamped_ntasks_value(payload_dict: dict, input_type: str, ntasks: int) -> int:
+def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     """
     Function that validates ntasks value in a simulation and returns the number of tasks that the simulation should use.
     It's used to prevents simulations with ntasks outside of range [1; primaries_count].

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -48,7 +48,7 @@ def make_input_dict(payload_dict: dict, input_type: str) -> dict:
 
 def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
     """
-    Function that validates ntasks value in a simulation and returns the number of tasks that  the simulation should use.
+    Function that validates ntasks value in a simulation and returns the number of tasks that the simulation should use.
     It's used to prevents simulations with ntasks outside of range [1; primaries_count].
     The ntasks value needs to be larger than 0, because you need at least a single task to run a simulation.
     The ntasks value also needs to be smaller than the number of primaries, because a task
@@ -77,10 +77,13 @@ def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
     elif next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None):
         input_file = next((file for file in payload_dict["input_files"] if file.endswith(".inp")), None)
         # read number of primaries from fluka file
-        all_input_lines: list[str] = payload_dict[input_file].split('\n')
+        all_input_lines: list[str] = payload_dict["input_files"][input_file].split('\n')
         # get value from START card
         start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
         number_of_all_primaries = int(float(start_card.split()[1]))
+    # if we cannot determine the file type, fallback to original ntasks
+    else:
+        return payload_dict["ntasks"]
 
     # if the number of tasks is larger than the number of primaries, clump the number of tasks to its value
     if payload_dict["ntasks"] > number_of_all_primaries:

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -71,7 +71,7 @@ def get_clamped_ntasks_value(payload_dict: dict, ntasks: int) -> int:
     number_of_all_primaries = get_total_number_of_primaries(payload_dict)
 
     # if we couldn't get the total number of primaries, fall back to the original ntasks value
-    if not number_of_all_primaries:
+    if number_of_all_primaries is not None:
         return ntasks
 
     # if number of all primaries is less than 1, fall back to 1 task

--- a/yaptide/routes/utils/utils.py
+++ b/yaptide/routes/utils/utils.py
@@ -46,7 +46,7 @@ def make_input_dict(payload_dict: dict, input_type: str) -> dict:
     return input_dict
 
 
-def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
+def get_clamped_ntasks_value(payload_dict: dict, input_type: str, ntasks: int) -> int:
     """
     Function that validates ntasks value in a simulation and returns the number of tasks that the simulation should use.
     It's used to prevents simulations with ntasks outside of range [1; primaries_count].
@@ -58,12 +58,13 @@ def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
     Args:
         payload_dict: A dictionary containing the payload received from a request.
         input_type: Input type determining if the request used editor or files.
+        ntasks: Task count from the request to be clamped
 
     Returns:
         Integer value representing the ntasks value to use in the simulation.
     """
     # ensure there is at least 1 task
-    if payload_dict["ntasks"] < 1:
+    if ntasks < 1:
         return 1
 
     # get the number of primaries, depending on the input_type
@@ -83,12 +84,12 @@ def get_clumped_ntasks_value(payload_dict: dict, input_type: str) -> int:
         number_of_all_primaries = int(float(start_card.split()[1]))
     # if we cannot determine the file type, fallback to original ntasks
     else:
-        return payload_dict["ntasks"]
+        return ntasks
 
-    # if the number of tasks is larger than the number of primaries, clump the number of tasks to its value
-    if payload_dict["ntasks"] > number_of_all_primaries:
+    # if the number of tasks is larger than the number of primaries, clamp the number of tasks to its value
+    if ntasks > number_of_all_primaries:
         return number_of_all_primaries
 
     # if ntasks is within range, return the original value
-    return payload_dict["ntasks"]
+    return ntasks
 

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -129,7 +129,9 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
             if first_start_line:
                 # try-catch for index out of range and int conversion errors
                 try:
-                    return int(first_start_line.split()[1])
+                    # START values are often written as floats (e.g. 50000.0)
+                    # therfore we use a float first, to avoid excepting due to ValueError
+                    return int(float(first_start_line.split()[1]))
                 except (IndexError, ValueError):
                     return None
             # if there's no START line, return None

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -89,7 +89,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
 
     # get number of primaries when EDITOR was used
     if input_type == InputType.EDITOR:
-        # check with try-catch for the number of paricles variable and return it
+        # check with try-catch for the number of particles variable and return it
         # if it's not there, return None
         try:
             return payload_dict["input_json"]["beam"]["numberOfParticles"]
@@ -115,7 +115,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
         if file_type == SimulationType.SHIELDHIT:
             first_nstat_line = next((line for line in file_lines if line.lstrip().startswith('NSTAT')), None)
             if first_nstat_line:
-                # try-catch for index out of range and int convession esrors
+                # try-catch for index out of range and int conversion esrors
                 try:
                     return int(first_nstat_line.split()[1])
                 except (IndexError, ValueError):

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -208,7 +208,9 @@ def adjust_primaries_in_files_dict(payload_files_dict: dict, ntasks: int = None)
     return {}, 0
 
 
-def adjust_primaries_for_shieldhit_files(payload_files_dict: dict, ntasks: int = None, primaries_file: str = None) -> tuple[dict, int]:
+def adjust_primaries_for_shieldhit_files(payload_files_dict: dict,
+                                         ntasks: int = None,
+                                         primaries_file: str = None) -> tuple[dict, int]:
     """Adjusts number of primaries in beam.dat file for SHIELD-HIT12A"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
 
@@ -238,7 +240,9 @@ def adjust_primaries_for_shieldhit_files(payload_files_dict: dict, ntasks: int =
     return files_dict, int(number_of_all_primaries)
 
 
-def adjust_primaries_for_fluka_files(payload_files_dict: dict, ntasks: int = None, primaries_file: str = None) -> tuple[dict, int]:
+def adjust_primaries_for_fluka_files(payload_files_dict: dict,
+                                     ntasks: int = None,
+                                     primaries_file: str = None) -> tuple[dict, int]:
     """Adjusts number of primaries in *.inp file for FLUKA"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
 

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -54,7 +54,7 @@ def get_primaries_file_type_and_name(payload_dict: dict) -> tuple[Optional[Simul
         payload_dict: A dictionary containing the payload received from a request.
 
     Returns:
-        Tuple of FILE_TYPE enumerator and string containing the name of the file
+        Tuple of SimulationType enumerator and string containing the name of the file
         or the tuple of Nones if the file type couldn't be determined
     """
     # ensure that the payload contains the input files dictionary
@@ -72,6 +72,75 @@ def get_primaries_file_type_and_name(payload_dict: dict) -> tuple[Optional[Simul
 
     # if we couldn't determine the file type, return a tuple of Nones
     return None, None
+
+
+def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
+    """
+    Gets the total number of primary particles from the payload dictionary from a request
+    depending on the input type and the simulation type.
+
+    Args:
+        payload_dict: A dictionary containing the payload received from a request.
+
+    Returns:
+        Integer representing the total number of primaries or None if it cannot be acquired from given payload.
+    """
+    input_type = get_json_type(payload_dict)
+
+    # get number of primaries when EDITOR was used
+    if input_type == InputType.EDITOR:
+        # check with try-catch for the number of paricles variable and return it
+        # if it's not there, return None
+        try:
+            return payload_dict["input_json"]["beam"]["numberOfParticles"]
+        except KeyError:
+            return None
+
+    # get number of primaries when FILES were used
+    if input_type == InputType.FILES:
+        file_type, file_name = get_primaries_file_type_and_name(payload_dict)
+
+        # if we couldn't get the file, return None
+        if not file_type:
+            return None
+
+        # get file lines
+        # no need for key check since if the file_type is not None then we know it exists
+        file_lines: list[str] = payload_dict["input_files"][file_name].split('\n')
+
+        # return number of particles depending on the simulation type
+        # this could be more generalized by just defining startswith string,
+        # but a change to how one simulation type defines its files could break the generalization
+        # therefore I don't believe such specific operations should be generalized
+        if file_type == SimulationType.SHIELDHIT:
+            first_nstat_line = next((line for line in file_lines if line.lstrip().startswith('NSTAT')), None)
+            if first_nstat_line:
+                # try-catch for index out of range and int convession esrors
+                try:
+                    return int(first_nstat_line.split()[1])
+                except (IndexError, ValueError):
+                    return None
+            # if there's no NSTAT line, return None
+            else:
+                return None
+
+        if file_type == SimulationType.FLUKA:
+            first_start_line = next((line for line in file_lines if line.lstrip().startswith('START')), None)
+            if first_start_line:
+                # try-catch for index out of range and int conversion errors
+                try:
+                    return int(first_start_line.split()[1])
+                except (IndexError, ValueError):
+                    return None
+            # if there's no START line, return None
+            else:
+                return None
+
+        # if the file_type is unknown, return None
+        return None
+
+    # if the input type couldn't be determined, return None
+    return None
 
 
 def convert_editor_dict_to_files_dict(editor_dict: dict, parser_type: str) -> dict:

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -4,11 +4,13 @@ import logging
 import re
 from enum import Enum, auto
 from pathlib import Path
+from typing import Optional
 
 from pymchelper.estimator import Estimator
 from pymchelper.writers.json import JsonWriter
 from pymchelper.flair.Input import Card
 from converter.api import (get_parser_from_str, run_parser)
+from yaptide.utils.enums import InputType, SimulationType
 
 NSTAT_MATCH = r"NSTAT\s*\d*\s*\d*"
 
@@ -36,18 +38,40 @@ def estimators_to_list(estimators_dict: dict, dir_path: Path) -> list[dict]:
     return result_estimators
 
 
-class JSON_TYPE(Enum):
-    """Class defining custom JSON types"""
-
-    Editor = auto()
-    Files = auto()
-
-
-def get_json_type(payload_dict: dict) -> JSON_TYPE:
+def get_json_type(payload_dict: dict) -> InputType:
     """Returns type of provided JSON"""
     if "input_files" in payload_dict:
-        return JSON_TYPE.Files
-    return JSON_TYPE.Editor
+        return InputType.FILES
+    return InputType.EDITOR
+
+
+def get_primaries_file_type_and_name(payload_dict: dict) -> tuple[Optional[SimulationType], Optional[str]]:
+    """
+    Function used for getting the file type and name that contains the primaries
+    from the payload dictionary received from a request.
+
+    Args:
+        payload_dict: A dictionary containing the payload received from a request.
+
+    Returns:
+        Tuple of FILE_TYPE enumerator and string containing the name of the file
+        or the tuple of Nones if the file type couldn't be determined
+    """
+    # ensure that the payload contains the input files dictionary
+    input_files = payload_dict.get("input_files")
+    if not input_files:
+        return None, None
+
+    # determining input file type - that information should most certainly be passed in the payload,
+    # but now it's not, so we have to do this ugly thing
+    if "beam.dat" in input_files:
+        return SimulationType.SHIELDHIT, "beam.dat"
+    inp_file = next((file for file in input_files if file.endswith(".inp")), None)
+    if inp_file:
+        return SimulationType.FLUKA, inp_file
+
+    # if we couldn't determine the file type, return a tuple of Nones
+    return None, None
 
 
 def convert_editor_dict_to_files_dict(editor_dict: dict, parser_type: str) -> dict:
@@ -67,7 +91,7 @@ def check_and_convert_payload_to_files_dict(payload_dict: dict) -> dict:
     """
     files_dict = {}
     json_type = get_json_type(payload_dict)
-    if json_type == JSON_TYPE.Editor:
+    if json_type == InputType.EDITOR:
         files_dict = convert_editor_dict_to_files_dict(editor_dict=payload_dict["input_json"],
                                                        parser_type=payload_dict["sim_type"])
     else:
@@ -103,20 +127,27 @@ def adjust_primaries_in_files_dict(payload_files_dict: dict, ntasks: int = None)
     else:
         logging.warning("ntasks value was specified as %d and will be overwritten", ntasks)
 
-    input_files = payload_files_dict['input_files']
-    # determining input file type
-    # should be done in more robust way which will require a lot of refactoring to pass sim_type
-    if 'beam.dat' in input_files:
-        return adjust_primaries_for_shieldhit_files(payload_files_dict=payload_files_dict, ntasks=ntasks)
-    if next((file for file in input_files if file.endswith(".inp")), None):
-        return adjust_primaries_for_fluka_files(payload_files_dict=payload_files_dict, ntasks=ntasks)
+    file_type, file_name = get_primaries_file_type_and_name(payload_files_dict)
+    if file_type == SimulationType.SHIELDHIT:
+        return adjust_primaries_for_shieldhit_files(payload_files_dict=payload_files_dict,
+                                                    ntasks=ntasks,
+                                                    primaries_file=file_name)
+    if file_type == SimulationType.FLUKA:
+        return adjust_primaries_for_fluka_files(payload_files_dict=payload_files_dict,
+                                                ntasks=ntasks,
+                                                primaries_file=file_name)
     return {}, 0
 
 
-def adjust_primaries_for_shieldhit_files(payload_files_dict: dict, ntasks: int = None) -> tuple[dict, int]:
+def adjust_primaries_for_shieldhit_files(payload_files_dict: dict, ntasks: int = None, primaries_file: str = None) -> tuple[dict, int]:
     """Adjusts number of primaries in beam.dat file for SHIELD-HIT12A"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
-    all_beam_lines: list[str] = files_dict['beam.dat'].split('\n')
+
+    # if the primaries file name is not passed, use beam.dat
+    if not primaries_file:
+        primaries_file = "beam.dat"
+
+    all_beam_lines: list[str] = files_dict[primaries_file].split('\n')
     all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
     beam_lines_count = len(all_beam_lines_with_nstat)
     if beam_lines_count != 1:
@@ -131,22 +162,25 @@ def adjust_primaries_for_shieldhit_files(payload_files_dict: dict, ntasks: int =
             # it is important to specify 3rd argument as 1
             # because otherwise values further in line might be changed to
             all_beam_lines[i] = all_beam_lines[i].replace(number_of_all_primaries, primaries_per_task, 1)
-    files_dict['beam.dat'] = '\n'.join(all_beam_lines)
+    files_dict[primaries_file] = '\n'.join(all_beam_lines)
     # number_of_tasks = payload_files_dict['ntasks']  -> to be implemented in UI
     # here we manipulate the files_dict['beam.dat'] file to adjust number of primaries
     # we manipulate content of the file, no need to write the file to disk
     return files_dict, int(number_of_all_primaries)
 
 
-def adjust_primaries_for_fluka_files(payload_files_dict: dict, ntasks: int = None) -> tuple[dict, int]:
+def adjust_primaries_for_fluka_files(payload_files_dict: dict, ntasks: int = None, primaries_file: str = None) -> tuple[dict, int]:
     """Adjusts number of primaries in *.inp file for FLUKA"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
-    input_file = next((file for file in files_dict if file.endswith(".inp")), None)
-    if not input_file:
-        return {}, 0
+
+    # if the primaries file name is not passed, get it from payload
+    if not primaries_file:
+        primaries_file = next((file for file in files_dict if file.endswith(".inp")), None)
+        if not primaries_file:
+            return {}, 0
 
     # read number of primaries from fluka file
-    all_input_lines: list[str] = files_dict[input_file].split('\n')
+    all_input_lines: list[str] = files_dict[primaries_file].split('\n')
     # get value from START card
     start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
     number_of_all_primaries = start_card.split()[1]
@@ -162,7 +196,7 @@ def adjust_primaries_for_fluka_files(payload_files_dict: dict, ntasks: int = Non
             start_card = str(card)
             all_input_lines[i] = start_card
             break
-    files_dict[input_file] = '\n'.join(all_input_lines)
+    files_dict[primaries_file] = '\n'.join(all_input_lines)
     return files_dict, parsed_number_of_all_primaries
 
 
@@ -174,12 +208,12 @@ def files_dict_with_adjusted_primaries(payload_dict: dict, ntasks: int = None) -
     returns dict with input files and full number of requested primaries
     """
     json_type = get_json_type(payload_dict)
-    if json_type == JSON_TYPE.Editor:
+    if json_type == InputType.EDITOR:
         new_payload_dict = copy.deepcopy(payload_dict)
         new_payload_dict["input_json"], number_of_all_primaries = adjust_primaries_in_editor_dict(
             payload_editor_dict=payload_dict, ntasks=ntasks)
         return check_and_convert_payload_to_files_dict(new_payload_dict), number_of_all_primaries
-    if json_type == JSON_TYPE.Files:
+    if json_type == InputType.FILES:
         files_dict, number_of_all_primaries = adjust_primaries_in_files_dict(payload_files_dict=payload_dict,
                                                                              ntasks=ntasks)
         return files_dict, number_of_all_primaries

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -2,7 +2,6 @@ import copy
 import json
 import logging
 import re
-from enum import Enum, auto
 from pathlib import Path
 from typing import Optional
 

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -114,7 +114,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
         if file_type == SimulationType.SHIELDHIT:
             first_nstat_line = next((line for line in file_lines if line.lstrip().startswith('NSTAT')), None)
             if first_nstat_line:
-                # try-catch for index out of range and int conversion esrors
+                # try-catch for index out of range and int conversion errors
                 try:
                     return int(first_nstat_line.split()[1])
                 except (IndexError, ValueError):
@@ -129,7 +129,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
                 # try-catch for index out of range and int conversion errors
                 try:
                     # START values are often written as floats (e.g. 50000.0)
-                    # therfore we use a float first, to avoid excepting due to ValueError
+                    # therefore we use a float first, to avoid excepting due to ValueError
                     return int(float(first_start_line.split()[1]))
                 except (IndexError, ValueError):
                     return None

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -44,7 +44,8 @@ def get_json_type(payload_dict: dict) -> InputType:
     return InputType.EDITOR
 
 
-def get_primaries_file_type_and_name(payload_dict: dict) -> tuple[Optional[SimulationType], Optional[str]]:
+def get_simulator_type_and_particle_source_input_file(
+        payload_dict: dict) -> tuple[Optional[SimulationType], Optional[str]]:
     """
     Function used for getting the file type and name that contains the primaries
     from the payload dictionary received from a request.
@@ -97,7 +98,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
 
     # get number of primaries when FILES were used
     if input_type == InputType.FILES:
-        file_type, file_name = get_primaries_file_type_and_name(payload_dict)
+        file_type, file_name = get_simulator_type_and_particle_source_input_file(payload_dict)
 
         # if we couldn't get the file, return None
         if not file_type:
@@ -197,29 +198,24 @@ def adjust_primaries_in_files_dict(payload_files_dict: dict, ntasks: int = None)
     else:
         logging.warning("ntasks value was specified as %d and will be overwritten", ntasks)
 
-    file_type, file_name = get_primaries_file_type_and_name(payload_files_dict)
+    file_type, file_name = get_simulator_type_and_particle_source_input_file(payload_files_dict)
     if file_type == SimulationType.SHIELDHIT:
         return adjust_primaries_for_shieldhit_files(payload_files_dict=payload_files_dict,
                                                     ntasks=ntasks,
-                                                    primaries_file=file_name)
+                                                    beam_dat_file=file_name)
     if file_type == SimulationType.FLUKA:
         return adjust_primaries_for_fluka_files(payload_files_dict=payload_files_dict,
                                                 ntasks=ntasks,
-                                                primaries_file=file_name)
+                                                fluka_input_file=file_name)
     return {}, 0
 
 
 def adjust_primaries_for_shieldhit_files(payload_files_dict: dict,
                                          ntasks: int = None,
-                                         primaries_file: str = None) -> tuple[dict, int]:
+                                         beam_dat_file: str = "beam.dat") -> tuple[dict, int]:
     """Adjusts number of primaries in beam.dat file for SHIELD-HIT12A"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
-
-    # if the primaries file name is not passed, use beam.dat
-    if not primaries_file:
-        primaries_file = "beam.dat"
-
-    all_beam_lines: list[str] = files_dict[primaries_file].split('\n')
+    all_beam_lines: list[str] = files_dict[beam_dat_file].split('\n')
     all_beam_lines_with_nstat = [line for line in all_beam_lines if line.lstrip().startswith('NSTAT')]
     beam_lines_count = len(all_beam_lines_with_nstat)
     if beam_lines_count != 1:
@@ -234,7 +230,7 @@ def adjust_primaries_for_shieldhit_files(payload_files_dict: dict,
             # it is important to specify 3rd argument as 1
             # because otherwise values further in line might be changed to
             all_beam_lines[i] = all_beam_lines[i].replace(number_of_all_primaries, primaries_per_task, 1)
-    files_dict[primaries_file] = '\n'.join(all_beam_lines)
+    files_dict[beam_dat_file] = '\n'.join(all_beam_lines)
     # number_of_tasks = payload_files_dict['ntasks']  -> to be implemented in UI
     # here we manipulate the files_dict['beam.dat'] file to adjust number of primaries
     # we manipulate content of the file, no need to write the file to disk
@@ -243,18 +239,18 @@ def adjust_primaries_for_shieldhit_files(payload_files_dict: dict,
 
 def adjust_primaries_for_fluka_files(payload_files_dict: dict,
                                      ntasks: int = None,
-                                     primaries_file: str = None) -> tuple[dict, int]:
+                                     fluka_input_file: str = None) -> tuple[dict, int]:
     """Adjusts number of primaries in *.inp file for FLUKA"""
     files_dict = copy.deepcopy(payload_files_dict['input_files'])
 
     # if the primaries file name is not passed, get it from payload
-    if not primaries_file:
-        primaries_file = next((file for file in files_dict if file.endswith(".inp")), None)
-        if not primaries_file:
+    if not fluka_input_file:
+        fluka_input_file = next((file for file in files_dict if file.endswith(".inp")), None)
+        if not fluka_input_file:
             return {}, 0
 
     # read number of primaries from fluka file
-    all_input_lines: list[str] = files_dict[primaries_file].split('\n')
+    all_input_lines: list[str] = files_dict[fluka_input_file].split('\n')
     # get value from START card
     start_card = next((line for line in all_input_lines if line.lstrip().startswith('START')), None)
     number_of_all_primaries = start_card.split()[1]
@@ -270,7 +266,7 @@ def adjust_primaries_for_fluka_files(payload_files_dict: dict,
             start_card = str(card)
             all_input_lines[i] = start_card
             break
-    files_dict[primaries_file] = '\n'.join(all_input_lines)
+    files_dict[fluka_input_file] = '\n'.join(all_input_lines)
     return files_dict, parsed_number_of_all_primaries
 
 

--- a/yaptide/utils/sim_utils.py
+++ b/yaptide/utils/sim_utils.py
@@ -60,6 +60,7 @@ def get_simulator_type_and_particle_source_input_file(
     # ensure that the payload contains the input files dictionary
     input_files = payload_dict.get("input_files")
     if not input_files:
+        logging.warning("Received payload doesn't have the input_files dictionary.")
         return None, None
 
     # determining input file type - that information should most certainly be passed in the payload,
@@ -71,6 +72,7 @@ def get_simulator_type_and_particle_source_input_file(
         return SimulationType.FLUKA, inp_file
 
     # if we couldn't determine the file type, return a tuple of Nones
+    logging.warning("Couldn't determine the file type from the received payload.")
     return None, None
 
 
@@ -94,6 +96,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
         try:
             return payload_dict["input_json"]["beam"]["numberOfParticles"]
         except KeyError:
+            logging.warning("The payload received from the editor doesn't have the number of particles value.")
             return None
 
     # get number of primaries when FILES were used
@@ -102,6 +105,7 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
 
         # if we couldn't get the file, return None
         if not file_type:
+            logging.warning("Couldn't get the particle source input file from received payload.")
             return None
 
         # get file lines
@@ -139,9 +143,11 @@ def get_total_number_of_primaries(payload_dict: dict) -> Optional[int]:
                 return None
 
         # if the file_type is unknown, return None
+        logging.warning("The simulator type determined from payload is unknown.")
         return None
 
     # if the input type couldn't be determined, return None
+    logging.warning("Couldn't determine the input type when trying to get the total number of primaries.")
     return None
 
 


### PR DESCRIPTION
This PR adds a quick and easy fix of the bug mentioned in #1618 by taking a minimum of tasks and primaries.
I do think it may be kind of weird to see the task count be different from the requested one, so I believe that it maybe should be blocked on the inputs themselves, on the front-end side. Though the fix should probably still be included if someone wants to run simulations directly through the API calls.

I'm also interested by the phenomenon that number of primaries is also able to go down from the inputted one when it's value is not a divisor of number of tasks as it's being divided between them with no remainder (e.g. 19 primaries and 10 tasks => 1 primary per task => 10 primaries total). I presume it's not that big of a deal, since you usually want to have the number of primaries magnitudes greater than the number of tasks, but it's something I can change if it's worth pursuing.


Description:

This pull request introduces several improvements and refactorings to how simulation input types and the number of simulation tasks (`ntasks`) are handled and validated. The changes unify and clarify the use of input type enums, add robust validation for `ntasks` to prevent invalid simulation configurations, and refactor functions to be more general and maintainable.

Key improvements and changes:

**Input type handling and enums:**
* Replaced the custom `JSON_TYPE` enum with the standardized `InputType` enum throughout the codebase, updating all references and related logic for determining input types. [[1]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL39-R151) [[2]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL70-R171) [[3]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL177-R292) [[4]](diffhunk://#diff-8670b995eb9f58b14f5a7cab50215edce3442835f8cb4d7470ff657caf7a3820R5-R8) [[5]](diffhunk://#diff-8670b995eb9f58b14f5a7cab50215edce3442835f8cb4d7470ff657caf7a3820L81-R83) [[6]](diffhunk://#diff-8670b995eb9f58b14f5a7cab50215edce3442835f8cb4d7470ff657caf7a3820L92-R94)
* Refactored the `get_json_type` function to return `InputType` values and updated its usage across simulation preparation and testing code. [[1]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL39-R151) [[2]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL70-R171) [[3]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL177-R292) [[4]](diffhunk://#diff-8670b995eb9f58b14f5a7cab50215edce3442835f8cb4d7470ff657caf7a3820L81-R83) [[5]](diffhunk://#diff-8670b995eb9f58b14f5a7cab50215edce3442835f8cb4d7470ff657caf7a3820L92-R94)

**Simulation input file and primaries detection:**
* Added `get_simulator_type_and_particle_source_input_file` and `get_total_number_of_primaries` functions to robustly determine the simulation type, relevant input file, and the total number of primary particles from the payload, improving reliability and maintainability.

**ntasks validation and clamping:**
* Introduced `get_clamped_ntasks_value`, which ensures that the `ntasks` value is always within the valid range `[1, number_of_primaries]`, preventing simulation crashes due to invalid task counts. This function is now called in both batch and celery routes before simulation creation. [[1]](diffhunk://#diff-fbf454bac730996f942faf8a0d5fb46f06ccfaddef50324af9330b13d2256aafR48-R97) [[2]](diffhunk://#diff-fbf454bac730996f942faf8a0d5fb46f06ccfaddef50324af9330b13d2256aafR2-R7) [[3]](diffhunk://#diff-53fdd75abe66e84eaa5bd749cc3688b927d1cd4f36c0ab72461b7a4a75d251deL18-R19) [[4]](diffhunk://#diff-53fdd75abe66e84eaa5bd749cc3688b927d1cd4f36c0ab72461b7a4a75d251deR48-R51) [[5]](diffhunk://#diff-5fd9c29e3abb0af27a7b5c902fe0d58ec296cb83f4db5aedafb496ca2d1b1294L20-R21) [[6]](diffhunk://#diff-5fd9c29e3abb0af27a7b5c902fe0d58ec296cb83f4db5aedafb496ca2d1b1294R49-R52)

**Refactoring of primaries adjustment logic:**
* Refactored `adjust_primaries_in_files_dict`, `adjust_primaries_for_shieldhit_files`, and `adjust_primaries_for_fluka_files` to use the new simulator type and input file detection logic, making these functions more generic and robust to different input file names. [[1]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL106-R224) [[2]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL134-R259) [[3]](diffhunk://#diff-fd6ef04bceceed71a763cfa5341d99a30fd6c65292e0ac6922449b237079b25dL165-R275)

These changes collectively make the simulation submission process safer, more maintainable, and less error-prone.